### PR TITLE
Enhance Maven publish workflow with artifact uploads

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -76,4 +76,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: artifact
-          path: target/*.jar
+          path: target/*

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -71,3 +71,9 @@ jobs:
           MAVEN_USERNAME: ${{ secrets.maven_username }}
           MAVEN_PASSWORD: ${{ secrets.maven_password }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.maven_gpg_passphrase }}
+
+      - name: Upload JARs as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifact
+          path: target/*.jar

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -72,8 +72,8 @@ jobs:
           MAVEN_PASSWORD: ${{ secrets.maven_password }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.maven_gpg_passphrase }}
 
-      - name: Upload JARs as artifact
+      - name: Upload built artifact
         uses: actions/upload-artifact@v4
         with:
-          name: artifact
+          name: built-artifact
           path: target/*

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -97,3 +97,9 @@ jobs:
           git add .
           git commit -m "Update version to ${{ inputs.version }} for release"
           git push -u origin main
+
+      - name: Upload python package
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package
+          path: dist/*


### PR DESCRIPTION
Add steps to upload JAR and Python package artifacts in the Maven publish workflow, and clarify the naming of the upload steps.