### PR TITLE
fix: Refactor commit-and-push action to simplify push command

### DIFF
--- a/actions/commit-and-push/action.yml
+++ b/actions/commit-and-push/action.yml
@@ -14,10 +14,6 @@ inputs:
     description: "The commit message. Defaults to `Automated commit`."
     required: false
     default: "Automated commit"
-  branch_name:
-    description: "The branch to push the changes to. Defaults to `main`."
-    required: false
-    default: "main"
 
 runs:
   using: "composite"
@@ -41,7 +37,7 @@ runs:
       shell: bash
       run: |
         set -x
-        git push origin ${{ inputs.branch_name }}
+        git push origin HEAD
 
 branding:
   icon: "git-commit"


### PR DESCRIPTION
Simplify the push command in the commit-and-push action by using HEAD instead of a specified branch name. This change streamlines the process and reduces the need for additional input.