### PR TITLE
feat: cdxgen action prepares cyclondx report 

### DIFF
--- a/actions/cdxgen/action.yaml
+++ b/actions/cdxgen/action.yaml
@@ -106,5 +106,6 @@ runs:
         path: ${{ github.workspace }}/reports/
 
     - name: "Set output"
+      shell: bash
       run: |
         echo "Uploaded page artifact-idL: ${{ steps.upload.outputs.artifact_id }}" >> $GITHUB_STEP_SUMMARY

--- a/actions/cdxgen/action.yaml
+++ b/actions/cdxgen/action.yaml
@@ -14,7 +14,7 @@ inputs:
     required: false
 outputs:
   page-url:
-    description: "Random number"
+    description: "GitHub pages URL"
     value: ${{ steps.deployment.outputs.page_url }}
 runs:
   using: "composite"

--- a/actions/cdxgen/action.yaml
+++ b/actions/cdxgen/action.yaml
@@ -12,7 +12,10 @@ inputs:
   project_type:
     description: "Type of the project"
     required: false
-
+outputs:
+  page-url:
+    description: "Random number"
+    value: ${{ steps.deployment.outputs.page_url }}
 runs:
   using: "composite"
   steps:
@@ -55,9 +58,53 @@ runs:
         --reports-dir /app/reports --bom /app/${{ github.event.repository.name }}_sbom.json
       shell: bash
 
+    - name: "Create index.html"
+      shell: bash
+      run: |
+        cd ${GITHUB_WORKSPACE}
+        cp -f ${{ github.event.repository.name }}_sbom.json ./reports/${{ github.event.repository.name }}_sbom.json
+        cat > ./reports/index.html <<EOL
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <meta charset="UTF-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <title>DEPSCAN Report</title>
+        </head>
+        <body>
+            <div id="depscan-content">
+                <h1>DEPSCAN Analysis</h1>
+                <p>This is the DEPSCAN analysis report.</p>
+                <iframe src="./depscan.html"
+                height="500px" width="1000px">
+                </iframe>
+            </div>
+            <hr>
+            <h2>Related Files</h2>
+            <ul>
+                <li><a href="${{ github.event.repository.name }}_sbom.json" target="_blank">Download ${{ github.event.repository.name }}_sbom.json</a></li>
+                <li><a href="depscan.html" target="_blank">Download depscan.html</a></li>
+                <li><a href="depscan.pdf" target="_blank">Download depscan.pdf</a></li>
+                <li><a href="depscan-bom.json" target="_blank">Download depscan-bom.json</a></li>
+                <li><a href="license-bom.json" target="_blank">Download license-bom.json</a></li>
+            </ul>
+        </body>
+        </html>
+        EOL
+
     - name: "Upload Depscan report"
       uses: actions/upload-artifact@v4.6.0
       with:
         name: "DEPSCAN report"
-        path: ${{ github.workspace }}/**/reports/*
+        path: ${{ github.workspace }}/reports/*
         retention-days: 5
+
+    - name: Upload static files as artifact
+      id: upload
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: ${{ github.workspace }}/reports/
+
+    - name: "Set output"
+      run: |
+        echo "Uploaded page artifact-idL: ${{ steps.upload.outputs.artifact_id }}" >> $GITHUB_STEP_SUMMARY

--- a/actions/cdxgen/action.yaml
+++ b/actions/cdxgen/action.yaml
@@ -109,4 +109,4 @@ runs:
     - name: "Set output"
       shell: bash
       run: |
-        echo "Uploaded page artifact-idL: ${{ steps.upload.outputs.artifact_id }}" >> $GITHUB_STEP_SUMMARY
+        echo "Uploaded page artifact-id: ${{ steps.upload.outputs.artifact_id }}" >> $GITHUB_STEP_SUMMARY

--- a/actions/cdxgen/action.yaml
+++ b/actions/cdxgen/action.yaml
@@ -63,7 +63,7 @@ runs:
       run: |
         cd ${GITHUB_WORKSPACE}
         sudo cp -f ${{ github.event.repository.name }}_sbom.json ./reports/${{ github.event.repository.name }}_sbom.json
-        sudo cat > ./reports/index.html <<EOL
+        cat > ./index.html <<EOL
         <!DOCTYPE html>
         <html lang="en">
         <head>
@@ -91,6 +91,7 @@ runs:
         </body>
         </html>
         EOL
+        sudo cp -f ./index.html ./reports/index.html
 
     - name: "Upload Depscan report"
       uses: actions/upload-artifact@v4.6.0

--- a/actions/cdxgen/action.yaml
+++ b/actions/cdxgen/action.yaml
@@ -92,6 +92,8 @@ runs:
         </html>
         EOL
         sudo cp -f ./index.html ./reports/index.html
+        sudo mkdir -p ./output/cyclondx-report
+        sudo cp -rf ./reports/* ./output/cyclondx-report
 
     - name: "Upload Depscan report"
       uses: actions/upload-artifact@v4.6.0
@@ -104,7 +106,7 @@ runs:
       id: upload
       uses: actions/upload-pages-artifact@v3
       with:
-        path: ${{ github.workspace }}/reports/
+        path: ${{ github.workspace }}/output/
 
     - name: "Set output"
       shell: bash

--- a/actions/cdxgen/action.yaml
+++ b/actions/cdxgen/action.yaml
@@ -62,8 +62,8 @@ runs:
       shell: bash
       run: |
         cd ${GITHUB_WORKSPACE}
-        cp -f ${{ github.event.repository.name }}_sbom.json ./reports/${{ github.event.repository.name }}_sbom.json
-        cat > ./reports/index.html <<EOL
+        sudo cp -f ${{ github.event.repository.name }}_sbom.json ./reports/${{ github.event.repository.name }}_sbom.json
+        sudo cat > ./reports/index.html <<EOL
         <!DOCTYPE html>
         <html lang="en">
         <head>


### PR DESCRIPTION
to be published to GitHub pages
<!-- start messages -->
### Commit messages:
[borislavr](https://github.com/Netcracker/qubership-workflow-hub/commit/99a29bb13816cbcaa5aeacbcaccdf439a9e13b32) feat: enhance cdxgen action with HTML report generation and output settings
[borislavr](https://github.com/Netcracker/qubership-workflow-hub/commit/4d52da91deae0bb0f3cbbf02cbda47a7f7d51058) feat: set output shell to bash in cdxgen action
[borislavr](https://github.com/Netcracker/qubership-workflow-hub/commit/39561566ffeb2621e9e7c1dfc83d27dcfe4fe602) feat: use sudo for file operations in cdxgen action
[borislavr](https://github.com/Netcracker/qubership-workflow-hub/commit/9c5145e553c40f299fa7b03a45cb1463671dc67c) feat: update cdxgen action to generate and store index.html in reports directory
[borislavr](https://github.com/Netcracker/qubership-workflow-hub/commit/cbd2db1d03726277711ad8d1a12ff862e0b69fb1) fix: correct typo in output message for uploaded page artifact-id in cdxgen action
[borislavr](https://github.com/Netcracker/qubership-workflow-hub/commit/4e6cc14dd648d86754e2d218cfe47214832efef7) ci: fixed output param description
[borislavr](https://github.com/Netcracker/qubership-workflow-hub/commit/5307eb00aedad1a0f2fe5c57925a0d3e403f6c10) ci: Moved cdx report to output/cyclondx-report
<!-- end messages -->
