### PR TITLE
fix: Correct typo in input name from 'ownre' to 'owner' in custom event action

### DIFF
--- a/actions/custom-event/action.yml
+++ b/actions/custom-event/action.yml
@@ -11,7 +11,7 @@ inputs:
   github-token:
     description: "GitHub Token"
     required: true
-  ownre:
+  owner:
     description: "Owner of the repository"
     required: false
   repo:


### PR DESCRIPTION
fix: Correct typo in input name from 'ownre' to 'owner' in custom event action