### PR TITLE
fix: Fix input name typo and update input retrieval method

### DIFF
--- a/actions/custom-event/action.yml
+++ b/actions/custom-event/action.yml
@@ -11,7 +11,7 @@ inputs:
   github-token:
     description: "GitHub Token"
     required: true
-  ownre:
+  owner:
     description: "Owner of the repository"
     required: false
   repo:

--- a/actions/custom-event/dist/index.js
+++ b/actions/custom-event/dist/index.js
@@ -85,8 +85,8 @@ async function run() {
     const octokit = github.getOctokit(token);
     //const { owner, repo } = github.context.repo;
 
-    const owner =  github.getInput('owner') || github.context.repo.owner;
-    const repo =  github.getInput('repo') || github.context.repo.repo;
+    const owner =  core.getInput('owner') || github.context.repo.owner;
+    const repo =  core.getInput('repo') || github.context.repo.repo;
 
     const response = await octokit.rest.repos.createDispatchEvent({
       owner,

--- a/actions/custom-event/index.js
+++ b/actions/custom-event/index.js
@@ -27,8 +27,8 @@ async function run() {
     const octokit = github.getOctokit(token);
     //const { owner, repo } = github.context.repo;
 
-    const owner =  github.getInput('owner') || github.context.repo.owner;
-    const repo =  github.getInput('repo') || github.context.repo.repo;
+    const owner =  core.getInput('owner') || github.context.repo.owner;
+    const repo =  core.getInput('repo') || github.context.repo.repo;
 
     const response = await octokit.rest.repos.createDispatchEvent({
       owner,


### PR DESCRIPTION
Correct the typo in the input name from 'ownre' to 'owner' and update the input retrieval to use `core.getInput` for both owner and repo in the custom event action.