### PR TITLE
fix: Update PR assigner config to include assignee count

### DIFF
--- a/.github/pr-assigner-config.yml
+++ b/.github/pr-assigner-config.yml
@@ -1,3 +1,4 @@
 assignees:
   - nookyo
   - borislavr
+count: 1


### PR DESCRIPTION
Modify the PR assigner configuration to include a count for the assignees.