### PR TITLE
feat: Added parameters for cdxgen workflow and action

### DIFF
--- a/.github/workflows/cdxgen.yaml
+++ b/.github/workflows/cdxgen.yaml
@@ -1,0 +1,36 @@
+---
+
+# The workflow will generate the SBOM file for the repository
+# and vulerability scan report for the SBOM file using CycloneDX
+# The workflow will run on push to main branch and manually triggered workflows
+# The results will be stored in the action artifacts
+
+name: 'CDXGen'
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  cdxgen:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "cdxgen"
+        uses: netcracker/qubership-workflow-hub/actions/cdxgen@main
+  deploy-pages:
+    permissions:
+      id-token: write
+      pages: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: cdxgen
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+      - name: "Summary"
+        run: |
+          echo "${{ steps.deployment.outputs.page_url }}cyclondx-report" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/cdxgen.yaml
+++ b/.github/workflows/cdxgen.yaml
@@ -22,7 +22,8 @@ on:
   push:
     branches:
       - 'main'
-
+permissions:
+  contents: read
 env:
   NO_CYCLONE_REPORT: ${{ github.event.inputs.no-cyclone-report || false }}
   FETCH_LICENSE: ${{ github.event.inputs.fetch-license || false }}

--- a/.github/workflows/cdxgen.yaml
+++ b/.github/workflows/cdxgen.yaml
@@ -8,17 +8,43 @@
 name: 'CDXGen'
 on:
   workflow_dispatch:
+    inputs:
+      no-cyclone-report:
+        description: "Do not generate CycloneDX report"
+        required: false
+        default: false
+        type: boolean
+      fetch-license:
+        description: "Fetch license information"
+        required: false
+        default: true
+        type: boolean
   push:
     branches:
       - 'main'
 
+env:
+  NO_CYCLONE_REPORT: ${{ github.event.inputs.no-cyclone-report || false }}
+  FETCH_LICENSE: ${{ github.event.inputs.fetch-license || false }}
+
 jobs:
   cdxgen:
+    outputs:
+      page-url: ${{ steps.cdxgen.outputs.page-url }}
     runs-on: ubuntu-latest
     steps:
+      - name: "Input parameters"
+        run: |
+          echo "NO_CYCLONE_REPORT=${NO_CYCLONE_REPORT}" >> $GITHUB_STEP_SUMMARY
+          echo "FETCH_LICENSE=${FETCH_LICENSE}" >> $GITHUB_STEP_SUMMARY
       - name: "cdxgen"
-        uses: netcracker/qubership-workflow-hub/actions/cdxgen@main
+        id: cdxgen
+        uses: netcracker/qubership-workflow-hub/actions/cdxgen@feature/cyclonedx
+        with:
+          no-cyclone-report: ${{ github.event.inputs.no-cyclone-report }}
+          fetch-license: ${{ github.event.inputs.fetch-license }}
   deploy-pages:
+    if: needs.cdxgen.outputs.page-url != ''
     permissions:
       id-token: write
       pages: write

--- a/actions/cdxgen/action.yaml
+++ b/actions/cdxgen/action.yaml
@@ -12,6 +12,14 @@ inputs:
   project_type:
     description: "Type of the project"
     required: false
+  no-cyclone-report:
+    description: "Do not generate CycloneDX report"
+    required: false
+    default: false
+  fetch-license:
+    description: "Fetch license information"
+    required: false
+    default: true
 outputs:
   page-url:
     description: "GitHub pages URL"
@@ -38,8 +46,8 @@ runs:
     - name: "Generate BOM"
       run: |
         cd ${GITHUB_WORKSPACE}
-        export FETCH_LICENSE=true
-        docker run --rm -e FETCH_LICENSE=true -v /tmp:/tmp -v $(pwd):/app:rw -t ghcr.io/cyclonedx/cdxgen:v8.6.0 -r /app -p -o /app/${{ github.event.repository.name }}_sbom.json "${{ env.PROJECT_TYPE }}"
+        export FETCH_LICENSE=${{ inputs.fetch-license }}
+        docker run --rm -e FETCH_LICENSE=${FETCH_LICENSE} -v /tmp:/tmp -v $(pwd):/app:rw -t ghcr.io/cyclonedx/cdxgen:v8.6.0 -r /app -p -o /app/${{ github.event.repository.name }}_sbom.json "${{ env.PROJECT_TYPE }}"
         docker rmi -f $(docker images -aq)
       shell: bash
 
@@ -51,14 +59,16 @@ runs:
         retention-days: 5
 
     - name: "Generate Depscan report"
+      if: ${{ !inputs.no-cyclone-report }}
       run: |
         cd ${GITHUB_WORKSPACE}
-        export FETCH_LICENSE=true
-        docker run --rm -e FETCH_LICENSE=true -v $PWD:/app ghcr.io/owasp-dep-scan/dep-scan --src /app \
+        export FETCH_LICENSE=${{ inputs.fetch-license }}
+        docker run --rm -e FETCH_LICENSE=${FETCH_LICENSE} -v $PWD:/app ghcr.io/owasp-dep-scan/dep-scan --src /app \
         --reports-dir /app/reports --bom /app/${{ github.event.repository.name }}_sbom.json
       shell: bash
 
     - name: "Create index.html"
+      if: ${{ !inputs.no-cyclone-report }}
       shell: bash
       run: |
         cd ${GITHUB_WORKSPACE}
@@ -96,6 +106,7 @@ runs:
         sudo cp -rf ./reports/* ./output/cyclondx-report
 
     - name: "Upload Depscan report"
+      if: ${{ !inputs.no-cyclone-report }}
       uses: actions/upload-artifact@v4.6.0
       with:
         name: "DEPSCAN report"
@@ -103,12 +114,14 @@ runs:
         retention-days: 5
 
     - name: Upload static files as artifact
+      if: ${{ !inputs.no-cyclone-report }}
       id: upload
       uses: actions/upload-pages-artifact@v3
       with:
         path: ${{ github.workspace }}/output/
 
     - name: "Set output"
+      if: ${{ !inputs.no-cyclone-report }}
       shell: bash
       run: |
         echo "Uploaded page artifact-id: ${{ steps.upload.outputs.artifact_id }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
```yaml
      no-cyclone-report:
        description: "Do not generate CycloneDX report"
        required: false
        default: false
        type: boolean
      fetch-license:
        description: "Fetch license information"
        required: false
        default: true
        type: boolean
```

<!-- start messages -->
### Commit messages:
[borislavr](https://github.com/Netcracker/qubership-workflow-hub/commit/ea4135f9399f17ad3f0a6b8c70831f5909baf7c9) feat: add options to fetch license information and control CycloneDX report generation
[borislavr](https://github.com/Netcracker/qubership-workflow-hub/commit/1393791433c657829281b3c0bfd22c6707ce7b41) feat: add CDXGen workflow for SBOM generation and vulnerability scanning
[borislavr](https://github.com/Netcracker/qubership-workflow-hub/commit/f80be506dffaf73f4798fe365f38d2570fd63df4) feat: add input parameters for CycloneDX report generation and license fetching in CDXGen workflow
[borislavr](https://github.com/Netcracker/qubership-workflow-hub/commit/e296cee60391a2488934f5c3fe6df5478511bc51) feat: add permissions for read access to contents in CDXGen workflow
<!-- end messages -->

