### PR TITLE
feat: cdxgen refactoring

### DIFF
--- a/.github/workflows/cdxgen.yaml
+++ b/.github/workflows/cdxgen.yaml
@@ -17,14 +17,13 @@ on:
   push:
     branches:
       - 'main'
-      - 'feature/*'
 
 jobs:
   cdxgen:
     runs-on: ubuntu-latest
     steps:
       - name: "cdxgen"
-        uses: netcracker/qubership-workflow-hub/actions/cdxgen@feature/cdxgen-refactoring
+        uses: netcracker/qubership-workflow-hub/actions/cdxgen@main
         with:
           generate_cdx_report: ${{ github.event.inputs.generate_cdx_report }}
   deploy-pages:

--- a/.github/workflows/cdxgen.yaml
+++ b/.github/workflows/cdxgen.yaml
@@ -12,7 +12,8 @@ on:
       generate_cdx_report:
         description: "Generate CycloneDX report"
         required: false
-        default: "false"
+        default: false
+        type: boolean
   push:
     branches:
       - 'main'
@@ -25,9 +26,9 @@ jobs:
       - name: "cdxgen"
         uses: netcracker/qubership-workflow-hub/actions/cdxgen@feature/cdxgen-refactoring
         with:
-          generate_cdx_report: ${{ github.event.inputs.generate_cdx_report || 'false' }}
+          generate_cdx_report: ${{ github.event.inputs.generate_cdx_report }}
   deploy-pages:
-    if: ${{ github.event.inputs.generate_cdx_report || 'false' }} == 'true'
+    if: ${{ github.event.inputs.generate_cdx_report }}
     permissions:
       id-token: write
       pages: write

--- a/.github/workflows/cdxgen.yaml
+++ b/.github/workflows/cdxgen.yaml
@@ -8,17 +8,26 @@
 name: 'CDXGen'
 on:
   workflow_dispatch:
+    inputs:
+      generate_cdx_report:
+        description: "Generate CycloneDX report"
+        required: false
+        default: "false"
   push:
     branches:
       - 'main'
+      - 'feature/*'
 
 jobs:
   cdxgen:
     runs-on: ubuntu-latest
     steps:
       - name: "cdxgen"
-        uses: netcracker/qubership-workflow-hub/actions/cdxgen@main
+        uses: netcracker/qubership-workflow-hub/actions/cdxgen@feature/cdxgen-refactoring
+        with:
+          generate_cdx_report: ${{ github.event.inputs.generate_cdx_report || 'false' }}
   deploy-pages:
+    if: ${{ github.event.inputs.generate_cdx_report || 'false' }} == 'true'
     permissions:
       id-token: write
       pages: write

--- a/actions/cdxgen/action.yaml
+++ b/actions/cdxgen/action.yaml
@@ -12,6 +12,10 @@ inputs:
   project_type:
     description: "Type of the project"
     required: false
+  generate_cdx_report:
+    description: "Generate CycloneDX report"
+    required: false
+    default: "false"
 outputs:
   page-url:
     description: "GitHub pages URL"
@@ -55,6 +59,7 @@ runs:
         retention-days: 5
 
     - name: "Generate Depscan report"
+      if: ${{ inputs.generate_cdx_report == 'true' }}
       run: |
         cd ${GITHUB_WORKSPACE}
         export FETCH_LICENSE=true
@@ -63,6 +68,7 @@ runs:
       shell: bash
 
     - name: "Create index.html"
+      if: ${{ inputs.generate_cdx_report == 'true' }}
       shell: bash
       run: |
         cd ${GITHUB_WORKSPACE}
@@ -100,6 +106,7 @@ runs:
         sudo cp -rf ./reports/* ./output/cyclondx-report
 
     - name: "Upload Depscan report"
+      if: ${{ inputs.generate_cdx_report == 'true' }}
       uses: actions/upload-artifact@v4.6.0
       with:
         name: "DEPSCAN report"
@@ -107,12 +114,14 @@ runs:
         retention-days: 5
 
     - name: Upload static files as artifact
+      if: ${{ inputs.generate_cdx_report == 'true' }}
       id: upload
       uses: actions/upload-pages-artifact@v3
       with:
         path: ${{ github.workspace }}/output/
 
     - name: "Set output"
+      if: ${{ inputs.generate_cdx_report == 'true' }}
       shell: bash
       run: |
         echo "Uploaded page artifact-id: ${{ steps.upload.outputs.artifact_id }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Added condition to run CycloneDX vulnerability repost or not
<!-- start messages -->
### Commit messages:
[borislavr](https://github.com/Netcracker/qubership-workflow-hub/commit/ec45d811b32bd380b7331f9ae63a819f008769e4) feat: add input option to generate CycloneDX report in CDXGen workflow
[borislavr](https://github.com/Netcracker/qubership-workflow-hub/commit/004b4ba20111c421cb933e9b9187466e38738b18) fix: update cdxgen workflow to use boolean type for generate_cdx_report input
[borislavr](https://github.com/Netcracker/qubership-workflow-hub/commit/dfa25aa13a6c132cc6f3c5a2d7c193ecdf6c9b2f) fix: update cdxgen workflow to use main branch for cdxgen action
<!-- end messages -->
