### PR TITLE
feat: use multiline message for broadcast so PR title is not too long

### DIFF
--- a/.github/workflows/broadcast-files.yml
+++ b/.github/workflows/broadcast-files.yml
@@ -70,7 +70,10 @@ jobs:
         exclude_forked: true
         committer_username: NetcrackerCLPLCI
         bot_branch_name: broadcast-bot
-        commit_message: 'ci: update of editorconfig file. If changes needed please contribute to https://github.com/Netcracker/.github/blob/main/.editorconfig'
+        commit_message: |
+          ci: update of editorconfig file
+
+          If changes needed please contribute to https://github.com/Netcracker/.github/blob/main/.editorconfig
   replicate_cloud_core_dependabot:
     name: Replicate dependabot config file for Cloud-Core repos
     runs-on: ubuntu-latest


### PR DESCRIPTION
PR title includes the first line of the commit message, so let's put the hint on the second line