### PR TITLE
chore: remove excessive DEFAULT_BRANCH setting from super-linter as it detects the branch automatically

### DIFF
--- a/.github/workflows/super-linter.yaml
+++ b/.github/workflows/super-linter.yaml
@@ -48,7 +48,6 @@ jobs:
       uses: super-linter/super-linter/slim@v7.3.0
       env:
         VALIDATE_ALL_CODEBASE: ${{ inputs.full_scan || false }}
-        DEFAULT_BRANCH: "main"
         # To report GitHub Actions status checks
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
See https://github.com/super-linter/super-linter/pull/5242