### PR TITLE
feat: Added maven-release action

### DIFF
--- a/.github/workflows/tag-creator.yml
+++ b/.github/workflows/tag-creator.yml
@@ -29,8 +29,8 @@ jobs:
 
       - name: Create tag
         run: |
-          git config --global user.email "qubership-actios[bot]"
-          git config --global user.name "qubership-actios[bot]@qubership.com"
+          git config --global user.email "qubership-actions[bot]"
+          git config --global user.name "qubership-actions[bot]@qubership.com"
           git tag -a ${{ inputs.tag-name }} -m "Tag ${{ inputs.tag-name }}"
 
       - name: Push tag

--- a/actions/commit-and-push/README.md
+++ b/actions/commit-and-push/README.md
@@ -13,8 +13,8 @@ This Action automates the process of committing changes and pushing them to a re
 
 | Name             | Description                            | Required | Default                               |
 | ---------------- | -------------------------------------- | -------- | ------------------------------------- |
-| `author_name`    | The name of the commit author.         | No       | `qubership-actios[bot]`               |
-| `author_email`   | The email of the commit author.        | No       | `qubership-actios[bot]@qubership.com` |
+| `author_name`    | The name of the commit author.         | No       | `qubership-actions[bot]`               |
+| `author_email`   | The email of the commit author.        | No       | `qubership-actions[bot]@qubership.com` |
 | `commit_message` | The commit message for the new commit. | No       | `Automated commit`                    |
 
 

--- a/actions/commit-and-push/README.md
+++ b/actions/commit-and-push/README.md
@@ -17,7 +17,6 @@ This Action automates the process of committing changes and pushing them to a re
 | `author_email`   | The email of the commit author.        | No       | `qubership-actions[bot]@qubership.com` |
 | `commit_message` | The commit message for the new commit. | No       | `Automated commit`                    |
 
-
 ## Usage Example
 
 Below is an example of how to use this action in a GitHub Actions workflow:

--- a/actions/commit-and-push/action.yml
+++ b/actions/commit-and-push/action.yml
@@ -3,13 +3,13 @@ description: "Automatically commits and pushes changes to the repository."
 
 inputs:
   author_name:
-    description: "The name of the commit author. Defaults to `qubership-actios[bot]`."
+    description: "The name of the commit author. Defaults to `qubership-actions[bot]`."
     required: false
-    default: "qubership-actios[bot]"
+    default: "qubership-actions[bot]"
   author_email:
-    description: "The email of the commit author. Defaults to `qubership-actios[bot]@qubership.com`."
+    description: "The email of the commit author. Defaults to `qubership-actions[bot]@qubership.com`."
     required: false
-    default: "qubership-actios[bot]@qubership.com"
+    default: "qubership-actions[bot]@qubership.com"
   commit_message:
     description: "[ci skip] The commit message. Defaults to `Automated commit`."
     required: false

--- a/actions/maven-release/action-script.sh
+++ b/actions/maven-release/action-script.sh
@@ -66,6 +66,7 @@ function bump_version_and_build() {
     if [ "${DRY_RUN}" != "false" ]; then
         echo "::group::Building ${MODULE} current version."
         echo "Dry run. Not bumping version."
+        # shellcheck disable=2086
         mvn --batch-mode deploy $MVN_ARGS ${PROFILE_ARG}
         if [ $? -ne 0 ]; then
             echo "Build failed. Exiting."
@@ -121,6 +122,7 @@ function bump_dependencies_versions() {
     VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
     export VERSION
     echo "::group::Building ${MODULE} version ${VERSION}"
+    # shellcheck disable=2086
     mvn --batch-mode deploy -DskipTests=true $MVN_ARGS ${PROFILE_ARG}
     if [ $? -ne 0 ]; then
         echo "Build failed. Exiting."

--- a/actions/maven-release/action-script.sh
+++ b/actions/maven-release/action-script.sh
@@ -64,7 +64,7 @@ function bump_version_and_build() {
         mvn --batch-mode deploy $MVN_ARGS ${PROFILE_ARG}
         if [ $? -ne 0 ]; then
             echo "Build failed. Exiting."
-            echo "❌ Dry-run: build ${MODULE} version ${RELEASE_VERSION} failsed." >> $GITHUB_STEP_SUMMARY
+            echo "❌ Dry-run: build ${MODULE} version ${RELEASE_VERSION} failed." >> $GITHUB_STEP_SUMMARY
             exit 1
         fi
         echo "::endgroup::"

--- a/actions/maven-release/action-script.sh
+++ b/actions/maven-release/action-script.sh
@@ -59,27 +59,27 @@ function bump_version_and_build() {
     git config --global user.name "qubership-actions[bot]"
     git config --global user.email "qubership-actions[bot]@users.noreply.github.com"
     if [ "${DRY_RUN}" != "false" ]; then
-        echo "::group::Buildin ${MODULE} current version."
+        echo "::group::Building ${MODULE} current version."
         echo "Dry run. Not bumping version."
-        mvn --batch-mode deploy $MVN_ARGS
-        echo "::endgroup::"
+        mvn --batch-mode deploy $MVN_ARGS ${PROFILE_ARG}
         if [ $? -ne 0 ]; then
             echo "Build failed. Exiting."
             echo "❌ Dry-run: build ${MODULE} version ${RELEASE_VERSION} failsed." >> $GITHUB_STEP_SUMMARY
             exit 1
         fi
+        echo "::endgroup::"
         export RELEASE_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
         echo "✔️ Dry-run: Successfully built ${MODULE} version ${RELEASE_VERSION}" >> $GITHUB_STEP_SUMMARY
     else
         echo "::group::Preparing ${MODULE} release."
         mvn --batch-mode versions:use-releases -DgenerateBackupPoms=false
         mvn --batch-mode release:prepare -DautoVersionSubmodules=true -DpushChanges=true -DtagNameFormat="v@{project.version}" ${RELEASE_VERSION_ARG} ${PROFILE_ARG}
-        echo "::endgroup::"
         if [ $? -ne 0 ]; then
             echo "Release preparation failed. Exiting."
             echo "❌ Release: preparation of ${MODULE} version ${RELEASE_VERSION} release failed." >> $GITHUB_STEP_SUMMARY
             exit 1
         fi
+        echo "::endgroup::"
         # scm.tag=v2.0.2
         export RELEASE_VERSION=$(sed -n "s/scm.tag=v//p" release.properties)
         echo "✅ Release: successfully prepared ${MODULE} version ${RELEASE_VERSION} release." >> $GITHUB_STEP_SUMMARY
@@ -91,13 +91,13 @@ function bump_version_and_build() {
         return
     fi
     echo "::group::Releasing ${MODULE} version ${RELEASE_VERSION}"
-    mvn --batch-mode release:perform -DpushChanges=true
-    echo "::endgroup::"
+    mvn --batch-mode release:perform -DpushChanges=true ${PROFILE_ARG}
     if [ $? -ne 0 ]; then
         echo "Release perform failed. Exiting."
         echo "❌ Release: ${MODULE} version ${RELEASE_VERSION} releas failed." >> $GITHUB_STEP_SUMMARY
         exit 1
     fi
+    echo "::endgroup::"
     echo "✅ Release: ${MODULE} version ${RELEASE_VERSION} released successfully." >> $GITHUB_STEP_SUMMARY
 }
 
@@ -110,22 +110,22 @@ function bump_dependencies_versions() {
     fi
     export VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
     echo "::group::Building ${MODULE} version ${VERSION}"
-    mvn --batch-mode deploy -DskipTests=true $MVN_ARGS
-    echo "::endgroup::"
+    mvn --batch-mode deploy -DskipTests=true $MVN_ARGS ${PROFILE_ARG}
     if [ $? -ne 0 ]; then
         echo "Build failed. Exiting."
         echo "❌ Build: ${MODULE} version ${VERSION} failed." >> $GITHUB_STEP_SUMMARY
         exit 1
     fi
+    echo "::endgroup::"
     echo "✅ Build: ${MODULE} version ${VERSION} built successfully." >> $GITHUB_STEP_SUMMARY
     echo "::group::Updating ${MODULE} dependencies versions to next-snapshot"
     mvn --batch-mode versions:use-next-snapshots -DgenerateBackupPoms=false -Dincludes="org.qubership.cloud*:*,org.qubership.core*:*"
-    echo "::endgroup::"
     if [ $? -ne 0 ]; then
         echo "Update dependencies failed. Exiting."
         echo "❌ Update: ${MODULE} dependencies versions to next-snapshot failed." >> $GITHUB_STEP_SUMMARY
         exit 1
     fi
+    echo "::endgroup::"
     echo "::group::Clean and commit pom.xml with next-snapshot version."
     echo "Committing pom.xml with release version."
     mvn --batch-mode clean

--- a/actions/maven-release/action-script.sh
+++ b/actions/maven-release/action-script.sh
@@ -23,8 +23,8 @@ function check_token() {
 
 function set_release_version() {
     cd ${GITHUB_WORKSPACE}/${MODULE}
-    git config --global user.name "${GITHUB_ACTOR}"
-    git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+    git config --global user.name "qubership-actions[bot]"
+    git config --global user.email "qubership-actions[bot]@users.noreply.github.com"
     echo "Bumping ${MODULE} version"
     if [ "${DRY_RUN}" != "false" ]; then
         echo "Dry run. Not bumping version."
@@ -56,8 +56,8 @@ function set_profile() {
 
 function bump_version_and_build() {
     cd ${GITHUB_WORKSPACE}/${MODULE}
-    git config --global user.name "${GITHUB_ACTOR}"
-    git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+    git config --global user.name "qubership-actions[bot]"
+    git config --global user.email "qubership-actions[bot]@users.noreply.github.com"
     if [ "${DRY_RUN}" != "false" ]; then
         echo "::group::Buildin ${MODULE} current version."
         echo "Dry run. Not bumping version."

--- a/actions/maven-release/action-script.sh
+++ b/actions/maven-release/action-script.sh
@@ -68,6 +68,7 @@ function bump_version_and_build() {
         echo "Dry run. Not bumping version."
         # shellcheck disable=2086
         mvn --batch-mode deploy $MVN_ARGS ${PROFILE_ARG}
+        # shellcheck disable=2181
         if [ $? -ne 0 ]; then
             echo "Build failed. Exiting."
             echo "❌ Dry-run: build ${MODULE} version ${RELEASE_VERSION} failed." >> "$GITHUB_STEP_SUMMARY"
@@ -82,6 +83,7 @@ function bump_version_and_build() {
         mvn --batch-mode versions:use-releases -DgenerateBackupPoms=false
         # shellcheck disable=2086
         mvn --batch-mode release:prepare -DautoVersionSubmodules=true -DpushChanges=true -DtagNameFormat="v@{project.version}" ${RELEASE_VERSION_ARG} ${PROFILE_ARG}
+        # shellcheck disable=2181
         if [ $? -ne 0 ]; then
             echo "Release preparation failed. Exiting."
             echo "❌ Release: preparation of ${MODULE} version ${RELEASE_VERSION} release failed." >> "$GITHUB_STEP_SUMMARY"
@@ -102,6 +104,7 @@ function bump_version_and_build() {
     echo "::group::Releasing ${MODULE} version ${RELEASE_VERSION}"
     # shellcheck disable=2086
     mvn --batch-mode release:perform -DpushChanges=true ${PROFILE_ARG}
+    # shellcheck disable=2181
     if [ $? -ne 0 ]; then
         echo "Release perform failed. Exiting."
         echo "❌ Release: ${MODULE} version ${RELEASE_VERSION} releas failed." >> "$GITHUB_STEP_SUMMARY"
@@ -124,6 +127,7 @@ function bump_dependencies_versions() {
     echo "::group::Building ${MODULE} version ${VERSION}"
     # shellcheck disable=2086
     mvn --batch-mode deploy -DskipTests=true $MVN_ARGS ${PROFILE_ARG}
+    # shellcheck disable=2181
     if [ $? -ne 0 ]; then
         echo "Build failed. Exiting."
         echo "❌ Build: ${MODULE} version ${VERSION} failed." >> "$GITHUB_STEP_SUMMARY"
@@ -133,6 +137,7 @@ function bump_dependencies_versions() {
     echo "✅ Build: ${MODULE} version ${VERSION} built successfully." >> "$GITHUB_STEP_SUMMARY"
     echo "::group::Updating ${MODULE} dependencies versions to next-snapshot"
     mvn --batch-mode versions:use-next-snapshots -DgenerateBackupPoms=false -Dincludes="org.qubership.cloud*:*,org.qubership.core*:*"
+    # shellcheck disable=2181
     if [ $? -ne 0 ]; then
         echo "Update dependencies failed. Exiting."
         echo "❌ Update: ${MODULE} dependencies versions to next-snapshot failed." >> "$GITHUB_STEP_SUMMARY"
@@ -152,6 +157,7 @@ function bump_dependencies_versions() {
         git add .
         git commit -m "Bump dependencies versions to next-snapshot [skip ci]"
         git push
+        # shellcheck disable=2181
         if [ $? -ne 0 ]; then
             echo "Commit failed. Exiting."
             echo "❌ Commit: ${MODULE} pom.xml with next-snapshot version failed." >> "$GITHUB_STEP_SUMMARY"

--- a/actions/maven-release/action-script.sh
+++ b/actions/maven-release/action-script.sh
@@ -22,7 +22,8 @@ function check_token() {
 }
 
 function set_release_version() {
-    cd ${GITHUB_WORKSPACE}/${MODULE}
+    # shellcheck disable=2164
+    cd "${GITHUB_WORKSPACE}/${MODULE}"
     git config --global user.name "qubership-actions[bot]"
     git config --global user.email "qubership-actions[bot]@users.noreply.github.com"
     echo "Bumping ${MODULE} version"
@@ -31,31 +32,35 @@ function set_release_version() {
     else
         CURRENT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
         echo "Current version: ${CURRENT_VERSION}"
-        major=$(echo ${CURRENT_VERSION} | cut -d "." -f 1)
-        minor=$(echo ${CURRENT_VERSION} | cut -d "." -f 2)
-        patch=$(echo ${CURRENT_VERSION} | cut -d "." -f 3)
+        major=$(echo "${CURRENT_VERSION}" | cut -d "." -f 1)
+        minor=$(echo "${CURRENT_VERSION}" | cut -d "." -f 2)
+        # shellcheck disable=2034
+        patch=$(echo "${CURRENT_VERSION}" | cut -d "." -f 3)
         if [ "${VERSION_TYPE}" == "major" ]; then
-            export RELEASE_VERSION_ARG="-DreleaseVersion=$((major + 1)).0.0"
+            RELEASE_VERSION_ARG="-DreleaseVersion=$((major + 1)).0.0"
         elif [ "${VERSION_TYPE}" == "minor" ]; then
-            export RELEASE_VERSION_ARG="-DreleaseVersion=${major}.$((minor + 1)).0"
+            RELEASE_VERSION_ARG="-DreleaseVersion=${major}.$((minor + 1)).0"
         else
-            export RELEASE_VERSION_ARG=""
+            RELEASE_VERSION_ARG=""
         fi
+        export RELEASE_VERSION_ARG
     fi
 }
 
 function set_profile() {
     if [ "${PROFILE}" != "" ]; then
         echo "Using profile ${PROFILE}"
-        export PROFILE_ARG="-P${PROFILE}"
+        PROFILE_ARG="-P${PROFILE}"
     else
         echo "No profile specified"
-        export PROFILE_ARG=""
+        PROFILE_ARG=""
     fi
+    export PROFILE_ARG
 }
 
 function bump_version_and_build() {
-    cd ${GITHUB_WORKSPACE}/${MODULE}
+    # shellcheck disable=2164
+    cd "${GITHUB_WORKSPACE}/${MODULE}"
     git config --global user.name "qubership-actions[bot]"
     git config --global user.email "qubership-actions[bot]@users.noreply.github.com"
     if [ "${DRY_RUN}" != "false" ]; then
@@ -64,65 +69,71 @@ function bump_version_and_build() {
         mvn --batch-mode deploy $MVN_ARGS ${PROFILE_ARG}
         if [ $? -ne 0 ]; then
             echo "Build failed. Exiting."
-            echo "❌ Dry-run: build ${MODULE} version ${RELEASE_VERSION} failed." >> $GITHUB_STEP_SUMMARY
+            echo "❌ Dry-run: build ${MODULE} version ${RELEASE_VERSION} failed." >> "$GITHUB_STEP_SUMMARY"
             exit 1
         fi
         echo "::endgroup::"
-        export RELEASE_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-        echo "✔️ Dry-run: Successfully built ${MODULE} version ${RELEASE_VERSION}" >> $GITHUB_STEP_SUMMARY
+        RELEASE_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+        export RELEASE_VERSION
+        echo "✔️ Dry-run: Successfully built ${MODULE} version ${RELEASE_VERSION}" >> "$GITHUB_STEP_SUMMARY"
     else
         echo "::group::Preparing ${MODULE} release."
         mvn --batch-mode versions:use-releases -DgenerateBackupPoms=false
+        # shellcheck disable=2086
         mvn --batch-mode release:prepare -DautoVersionSubmodules=true -DpushChanges=true -DtagNameFormat="v@{project.version}" ${RELEASE_VERSION_ARG} ${PROFILE_ARG}
         if [ $? -ne 0 ]; then
             echo "Release preparation failed. Exiting."
-            echo "❌ Release: preparation of ${MODULE} version ${RELEASE_VERSION} release failed." >> $GITHUB_STEP_SUMMARY
+            echo "❌ Release: preparation of ${MODULE} version ${RELEASE_VERSION} release failed." >> "$GITHUB_STEP_SUMMARY"
             exit 1
         fi
         echo "::endgroup::"
         # scm.tag=v2.0.2
-        export RELEASE_VERSION=$(sed -n "s/scm.tag=v//p" release.properties)
-        echo "✅ Release: successfully prepared ${MODULE} version ${RELEASE_VERSION} release." >> $GITHUB_STEP_SUMMARY
+        RELEASE_VERSION=$(sed -n "s/scm.tag=v//p" release.properties)
+        export RELEASE_VERSION
+        echo "✅ Release: successfully prepared ${MODULE} version ${RELEASE_VERSION} release." >> "$GITHUB_STEP_SUMMARY"
     fi
-    echo "RELEASE_VERSION=${RELEASE_VERSION}" >> $GITHUB_OUTPUT
+    echo "RELEASE_VERSION=${RELEASE_VERSION}" >> "$GITHUB_OUTPUT"
     echo "Building ${MODULE} version ${RELEASE_VERSION}"
     if [ "${DRY_RUN}" != "false" ]; then
         echo "Dry run. Not committing."
         return
     fi
     echo "::group::Releasing ${MODULE} version ${RELEASE_VERSION}"
+    # shellcheck disable=2086
     mvn --batch-mode release:perform -DpushChanges=true ${PROFILE_ARG}
     if [ $? -ne 0 ]; then
         echo "Release perform failed. Exiting."
-        echo "❌ Release: ${MODULE} version ${RELEASE_VERSION} releas failed." >> $GITHUB_STEP_SUMMARY
+        echo "❌ Release: ${MODULE} version ${RELEASE_VERSION} releas failed." >> "$GITHUB_STEP_SUMMARY"
         exit 1
     fi
     echo "::endgroup::"
-    echo "✅ Release: ${MODULE} version ${RELEASE_VERSION} released successfully." >> $GITHUB_STEP_SUMMARY
+    echo "✅ Release: ${MODULE} version ${RELEASE_VERSION} released successfully." >> "$GITHUB_STEP_SUMMARY"
 }
 
 function bump_dependencies_versions() {
-    cd ${GITHUB_WORKSPACE}/${MODULE}
+    # shellcheck disable=2164
+    cd "${GITHUB_WORKSPACE}/${MODULE}"
     # To update pom.xml dependencies with the next -SNAPSHOT version need to deploy SNAPSHOT version
     if [ "${DRY_RUN}" != "false" ]; then
         echo "Dry run. Not updating dependencies."
         return
     fi
-    export VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+    VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+    export VERSION
     echo "::group::Building ${MODULE} version ${VERSION}"
     mvn --batch-mode deploy -DskipTests=true $MVN_ARGS ${PROFILE_ARG}
     if [ $? -ne 0 ]; then
         echo "Build failed. Exiting."
-        echo "❌ Build: ${MODULE} version ${VERSION} failed." >> $GITHUB_STEP_SUMMARY
+        echo "❌ Build: ${MODULE} version ${VERSION} failed." >> "$GITHUB_STEP_SUMMARY"
         exit 1
     fi
     echo "::endgroup::"
-    echo "✅ Build: ${MODULE} version ${VERSION} built successfully." >> $GITHUB_STEP_SUMMARY
+    echo "✅ Build: ${MODULE} version ${VERSION} built successfully." >> "$GITHUB_STEP_SUMMARY"
     echo "::group::Updating ${MODULE} dependencies versions to next-snapshot"
     mvn --batch-mode versions:use-next-snapshots -DgenerateBackupPoms=false -Dincludes="org.qubership.cloud*:*,org.qubership.core*:*"
     if [ $? -ne 0 ]; then
         echo "Update dependencies failed. Exiting."
-        echo "❌ Update: ${MODULE} dependencies versions to next-snapshot failed." >> $GITHUB_STEP_SUMMARY
+        echo "❌ Update: ${MODULE} dependencies versions to next-snapshot failed." >> "$GITHUB_STEP_SUMMARY"
         exit 1
     fi
     echo "::endgroup::"
@@ -133,18 +144,18 @@ function bump_dependencies_versions() {
     if [ -z "${gitdiffstat}" ]
     then
         echo "No changes"
-        echo "ℹ️ Commit: There were no changed dependencies versions in ${MODULE} pom.xml." >> $GITHUB_STEP_SUMMARY
+        echo "ℹ️ Commit: There were no changed dependencies versions in ${MODULE} pom.xml." >> "$GITHUB_STEP_SUMMARY"
         return
     else
         git add .
         git commit -m "Bump dependencies versions to next-snapshot [skip ci]"
         git push
-        echo "::endgroup::"
         if [ $? -ne 0 ]; then
             echo "Commit failed. Exiting."
-            echo "❌ Commit: ${MODULE} pom.xml with next-snapshot version failed." >> $GITHUB_STEP_SUMMARY
+            echo "❌ Commit: ${MODULE} pom.xml with next-snapshot version failed." >> "$GITHUB_STEP_SUMMARY"
             exit 1
         fi
-        echo "✅ Commit: ${MODULE} pom.xml with next-snapshot version committed successfully." >> $GITHUB_STEP_SUMMARY
+        echo "✅ Commit: ${MODULE} pom.xml with next-snapshot version committed successfully." >> "$GITHUB_STEP_SUMMARY"
     fi
+    echo "::endgroup::"
 }

--- a/actions/maven-release/action-script.sh
+++ b/actions/maven-release/action-script.sh
@@ -1,0 +1,150 @@
+#! /usr/bin/env bash
+
+function check_version_type() {
+    if [[ $1 != "major" && $1 != "minor" && $1 != "patch" ]]; then
+        echo "Invalid version type. Please use major, minor or patch."
+        exit 1
+    fi
+}
+
+function check_module() {
+    if [ -z "$1" ]; then
+        echo "Module is required."
+        exit 1
+    fi
+}
+
+function check_token() {
+    if [ -z "$1" ]; then
+        echo "token input parameter is required."
+        exit 1
+    fi
+}
+
+function set_release_version() {
+    cd ${GITHUB_WORKSPACE}/${MODULE}
+    git config --global user.name "${GITHUB_ACTOR}"
+    git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+    echo "Bumping ${MODULE} version"
+    if [ "${DRY_RUN}" != "false" ]; then
+        echo "Dry run. Not bumping version."
+    else
+        CURRENT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+        echo "Current version: ${CURRENT_VERSION}"
+        major=$(echo ${CURRENT_VERSION} | cut -d "." -f 1)
+        minor=$(echo ${CURRENT_VERSION} | cut -d "." -f 2)
+        patch=$(echo ${CURRENT_VERSION} | cut -d "." -f 3)
+        if [ "${VERSION_TYPE}" == "major" ]; then
+            export RELEASE_VERSION_ARG="-DreleaseVersion=$((major + 1)).0.0"
+        elif [ "${VERSION_TYPE}" == "minor" ]; then
+            export RELEASE_VERSION_ARG="-DreleaseVersion=${major}.$((minor + 1)).0"
+        else
+            export RELEASE_VERSION_ARG=""
+        fi
+    fi
+}
+
+function set_profile() {
+    if [ "${PROFILE}" != "" ]; then
+        echo "Using profile ${PROFILE}"
+        export PROFILE_ARG="-P${PROFILE}"
+    else
+        echo "No profile specified"
+        export PROFILE_ARG=""
+    fi
+}
+
+function bump_version_and_build() {
+    cd ${GITHUB_WORKSPACE}/${MODULE}
+    git config --global user.name "${GITHUB_ACTOR}"
+    git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+    if [ "${DRY_RUN}" != "false" ]; then
+        echo "::group::Buildin ${MODULE} current version."
+        echo "Dry run. Not bumping version."
+        mvn --batch-mode deploy $MVN_ARGS
+        echo "::endgroup::"
+        if [ $? -ne 0 ]; then
+            echo "Build failed. Exiting."
+            echo "❌ Dry-run: build ${MODULE} version ${RELEASE_VERSION} failsed." >> $GITHUB_STEP_SUMMARY
+            exit 1
+        fi
+        export RELEASE_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+        echo "✔️ Dry-run: Successfully built ${MODULE} version ${RELEASE_VERSION}" >> $GITHUB_STEP_SUMMARY
+    else
+        echo "::group::Preparing ${MODULE} release."
+        mvn --batch-mode versions:use-releases -DgenerateBackupPoms=false
+        mvn --batch-mode release:prepare -DautoVersionSubmodules=true -DpushChanges=true -DtagNameFormat="v@{project.version}" ${RELEASE_VERSION_ARG} ${PROFILE_ARG}
+        echo "::endgroup::"
+        if [ $? -ne 0 ]; then
+            echo "Release preparation failed. Exiting."
+            echo "❌ Release: preparation of ${MODULE} version ${RELEASE_VERSION} release failed." >> $GITHUB_STEP_SUMMARY
+            exit 1
+        fi
+        # scm.tag=v2.0.2
+        export RELEASE_VERSION=$(sed -n "s/scm.tag=v//p" release.properties)
+        echo "✅ Release: successfully prepared ${MODULE} version ${RELEASE_VERSION} release." >> $GITHUB_STEP_SUMMARY
+    fi
+    echo "RELEASE_VERSION=${RELEASE_VERSION}" >> $GITHUB_OUTPUT
+    echo "Building ${MODULE} version ${RELEASE_VERSION}"
+    if [ "${DRY_RUN}" != "false" ]; then
+        echo "Dry run. Not committing."
+        return
+    fi
+    echo "::group::Releasing ${MODULE} version ${RELEASE_VERSION}"
+    mvn --batch-mode release:perform -DpushChanges=true
+    echo "::endgroup::"
+    if [ $? -ne 0 ]; then
+        echo "Release perform failed. Exiting."
+        echo "❌ Release: ${MODULE} version ${RELEASE_VERSION} releas failed." >> $GITHUB_STEP_SUMMARY
+        exit 1
+    fi
+    echo "✅ Release: ${MODULE} version ${RELEASE_VERSION} released successfully." >> $GITHUB_STEP_SUMMARY
+}
+
+function bump_dependencies_versions() {
+    cd ${GITHUB_WORKSPACE}/${MODULE}
+    # To update pom.xml dependencies with the next -SNAPSHOT version need to deploy SNAPSHOT version
+    if [ "${DRY_RUN}" != "false" ]; then
+        echo "Dry run. Not updating dependencies."
+        return
+    fi
+    export VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+    echo "::group::Building ${MODULE} version ${VERSION}"
+    mvn --batch-mode deploy -DskipTests=true $MVN_ARGS
+    echo "::endgroup::"
+    if [ $? -ne 0 ]; then
+        echo "Build failed. Exiting."
+        echo "❌ Build: ${MODULE} version ${VERSION} failed." >> $GITHUB_STEP_SUMMARY
+        exit 1
+    fi
+    echo "✅ Build: ${MODULE} version ${VERSION} built successfully." >> $GITHUB_STEP_SUMMARY
+    echo "::group::Updating ${MODULE} dependencies versions to next-snapshot"
+    mvn --batch-mode versions:use-next-snapshots -DgenerateBackupPoms=false -Dincludes="org.qubership.cloud*:*,org.qubership.core*:*"
+    echo "::endgroup::"
+    if [ $? -ne 0 ]; then
+        echo "Update dependencies failed. Exiting."
+        echo "❌ Update: ${MODULE} dependencies versions to next-snapshot failed." >> $GITHUB_STEP_SUMMARY
+        exit 1
+    fi
+    echo "::group::Clean and commit pom.xml with next-snapshot version."
+    echo "Committing pom.xml with release version."
+    mvn --batch-mode clean
+    gitdiffstat=$(git diff --stat)
+    if [ -z "${gitdiffstat}" ]
+    then
+        echo "No changes"
+        echo "ℹ️ Commit: There were no changed dependencies versions in ${MODULE} pom.xml." >> $GITHUB_STEP_SUMMARY
+        return
+    else
+        git add .
+        git commit -m "Bump dependencies versions to next-snapshot [skip ci]"
+        git push
+        echo "::endgroup::"
+        if [ $? -ne 0 ]; then
+            echo "Commit failed. Exiting."
+            echo "❌ Commit: ${MODULE} pom.xml with next-snapshot version failed." >> $GITHUB_STEP_SUMMARY
+            exit 1
+        fi
+        echo "✅ Commit: ${MODULE} pom.xml with next-snapshot version committed successfully." >> $GITHUB_STEP_SUMMARY
+    fi
+}

--- a/actions/maven-release/action.yaml
+++ b/actions/maven-release/action.yaml
@@ -1,0 +1,142 @@
+---
+name: Build Maven Artifact
+description: Build Maven artifact
+
+inputs:
+  version-type:
+    description: 'Version type to release. Can be one of [major, minor, patch]'
+    required: true
+    default: 'patch'
+    type: string
+  module:
+    description: 'Module to build == Repository name.'
+    required: true
+    default: ''
+    type: string
+  maven-args:
+    description: 'Maven arguments to pass'
+    required: false
+    default: '-DskipTests=true -Dmaven.javadoc.skip=true -B'
+    type: string
+  server-id:
+    description: 'Maven server ID'
+    required: false
+    default: 'github'
+    type: string
+  java-version:
+    description: 'Java version to use'
+    required: false
+    default: '21'
+    type: string
+  dry-run:
+    description: 'Dry run flag'
+    required: false
+    default: 'true'
+    type: string
+  token:
+    description: 'GitHub token'
+    required: true
+    default: ''
+    type: string
+  gpg-private-key:
+    description: 'GPG private key'
+    required: true
+    default: ''
+    type: string
+  gpg-passphrase:
+    description: 'GPG passphrase'
+    required: true
+    default: ''
+    type: string
+  profile:
+    description: 'Maven profile to use'
+    required: false
+    default: ''
+    type: string
+  bumb-dependencies-after-release:
+    description: 'Bump dependencies versions to next snapshot'
+    required: false
+    default: 'false'
+    type: string
+outputs:
+  release-version:
+    description: 'Release version'
+    value: ${{ steps.release.outputs.RELEASE_VERSION }}
+runs:
+  using: "composite"
+  steps:
+    - name: "Check inputs"
+      run: |
+        . ${GITHUB_ACTION_PATH}/action-script.sh
+        check_version_type "${{ inputs.version-type }}"
+        check_module "${{ inputs.module }}"
+        check_token "${{ inputs.token }}"
+        # set_env_vars "${{ inputs.module }}" "${{ inputs.version-type }}"
+      shell: bash
+
+    - name: Set up JDK
+      uses: actions/setup-java@v4
+      with:
+        java-version: ${{ inputs.java-version }}
+        distribution: 'temurin'
+        server-id: ${{ inputs.server-id }}
+        server-username: MAVEN_USERNAME
+        server-password: MAVEN_PASSWORD
+        gpg-private-key: ${{ inputs.gpg-private-key }}
+        gpg-passphrase: MAVEN_GPG_PASSPHRASE
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        ref: main
+        path: ${{ inputs.module }}
+        repository: ${{ github.repository_owner }}/${{ inputs.module }}
+        token: ${{ inputs.token }}
+    - name: "Release"
+      id: release
+      run: |
+        . ${GITHUB_ACTION_PATH}/action-script.sh
+        set_release_version
+        set_profile
+        bump_version_and_build
+      shell: bash
+      env:
+        MAVEN_USERNAME: ${{ github.actor }}
+        MAVEN_PASSWORD: ${{ inputs.token }}
+        MODULE: ${{ inputs.module }}
+        VERSION_TYPE: ${{ inputs.version-type }}
+        MVN_ARGS: ${{ inputs.maven-args }}
+        DRY_RUN: ${{ inputs.dry-run }}
+        GITHUB_TOKEN: ${{ inputs.token }}
+        MAVEN_GPG_PASSPHRASE: ${{ inputs.gpg-passphrase }}
+        PROFILE: ${{ inputs.profile }}
+        # SONAR_TOKEN: ${{ secrets.sonar-token }}
+    - name: Cleanup
+      if: ${{ inputs.dry-run == 'false' && inputs.bumb-dependencies-after-release == 'true' }}
+      run: |
+        rm -rf ${GITHUB_WORKSPACE}/${{ inputs.module }}
+      shell: bash
+    - name: Checkout
+      if: ${{ inputs.dry-run == 'false' && inputs.bumb-dependencies-after-release == 'true' }}
+      uses: actions/checkout@v4
+      with:
+        ref: main
+        path: ${{ inputs.module }}
+        repository: ${{ github.repository_owner }}/${{ inputs.module }}
+        token: ${{ inputs.token }}
+    - name: "Bump dependencies versions to next snapshot"
+      if: ${{ inputs.dry-run == 'false' && inputs.bumb-dependencies-after-release == 'true' }}
+      run: |
+        . ${GITHUB_ACTION_PATH}/action-script.sh
+        bump_dependencies_versions
+      shell: bash
+      env:
+        MAVEN_USERNAME: ${{ github.actor }}
+        MAVEN_PASSWORD: ${{ inputs.token }}
+        MODULE: ${{ inputs.module }}
+        VERSION_TYPE: ${{ inputs.version-type }}
+        MVN_ARGS: ${{ inputs.maven-args }}
+        DRY_RUN: ${{ inputs.dry-run }}
+        GITHUB_TOKEN: ${{ inputs.token }}
+        MAVEN_GPG_PASSPHRASE: ${{ secrets.gpg-passphrase }}
+        PROFILE: ${{ inputs.profile }}
+        # SONAR_TOKEN: ${{ secrets.sonar-token }}

--- a/actions/maven-release/action.yaml
+++ b/actions/maven-release/action.yaml
@@ -71,7 +71,6 @@ runs:
         check_version_type "${{ inputs.version-type }}"
         check_module "${{ inputs.module }}"
         check_token "${{ inputs.token }}"
-        # set_env_vars "${{ inputs.module }}" "${{ inputs.version-type }}"
       shell: bash
 
     - name: Set up JDK
@@ -109,7 +108,6 @@ runs:
         GITHUB_TOKEN: ${{ inputs.token }}
         MAVEN_GPG_PASSPHRASE: ${{ inputs.gpg-passphrase }}
         PROFILE: ${{ inputs.profile }}
-        # SONAR_TOKEN: ${{ secrets.sonar-token }}
     - name: Cleanup
       if: ${{ inputs.dry-run == 'false' && inputs.bumb-dependencies-after-release == 'true' }}
       run: |
@@ -139,4 +137,3 @@ runs:
         GITHUB_TOKEN: ${{ inputs.token }}
         MAVEN_GPG_PASSPHRASE: ${{ inputs.gpg-passphrase }}
         PROFILE: ${{ inputs.profile }}
-        # SONAR_TOKEN: ${{ secrets.sonar-token }}

--- a/actions/maven-release/action.yaml
+++ b/actions/maven-release/action.yaml
@@ -58,6 +58,16 @@ inputs:
     required: false
     default: ''
     type: string
+  maven-user:
+    description: 'Maven user'
+    required: false
+    default: ''
+    type: string
+  maven-password:
+    description: 'Maven password'
+    required: false
+    default: ''
+    type: string
   bumb-dependencies-after-release:
     description: 'Bump dependencies versions to next snapshot'
     required: false
@@ -104,8 +114,8 @@ runs:
         bump_version_and_build
       shell: bash
       env:
-        MAVEN_USERNAME: ${{ github.actor }}
-        MAVEN_PASSWORD: ${{ inputs.token }}
+        MAVEN_USERNAME: ${{ inputs.maven-user }}
+        MAVEN_PASSWORD: ${{ inputs.maven-password }}
         MODULE: ${{ inputs.module }}
         VERSION_TYPE: ${{ inputs.version-type }}
         MVN_ARGS: ${{ inputs.maven-args }}
@@ -133,8 +143,8 @@ runs:
         bump_dependencies_versions
       shell: bash
       env:
-        MAVEN_USERNAME: ${{ github.actor }}
-        MAVEN_PASSWORD: ${{ inputs.token }}
+        MAVEN_USERNAME: ${{ inputs.maven-user }}
+        MAVEN_PASSWORD: ${{ inputs.maven-password }}
         MODULE: ${{ inputs.module }}
         VERSION_TYPE: ${{ inputs.version-type }}
         MVN_ARGS: ${{ inputs.maven-args }}

--- a/actions/maven-release/action.yaml
+++ b/actions/maven-release/action.yaml
@@ -13,6 +13,11 @@ inputs:
     required: true
     default: ''
     type: string
+  ref:
+    description: 'Branch name to create release from'
+    required: false
+    default: 'main'
+    type: string
   maven-args:
     description: 'Maven arguments to pass'
     required: false
@@ -86,7 +91,7 @@ runs:
     - name: Checkout
       uses: actions/checkout@v4
       with:
-        ref: main
+        ref: ${{ inputs.ref }}
         path: ${{ inputs.module }}
         repository: ${{ github.repository_owner }}/${{ inputs.module }}
         token: ${{ inputs.token }}

--- a/actions/maven-release/action.yaml
+++ b/actions/maven-release/action.yaml
@@ -137,6 +137,6 @@ runs:
         MVN_ARGS: ${{ inputs.maven-args }}
         DRY_RUN: ${{ inputs.dry-run }}
         GITHUB_TOKEN: ${{ inputs.token }}
-        MAVEN_GPG_PASSPHRASE: ${{ secrets.gpg-passphrase }}
+        MAVEN_GPG_PASSPHRASE: ${{ inputs.gpg-passphrase }}
         PROFILE: ${{ inputs.profile }}
         # SONAR_TOKEN: ${{ secrets.sonar-token }}


### PR DESCRIPTION
maven-release action uses maven-release-plugin to release maven artifacts to Maven Central or GitHub packages









<!-- start messages -->
### Commit messages:
[borislavr](https://github.com/Netcracker/qubership-workflow-hub/commit/f41d6eb7d88672b18f19fa506398abfca7481c81) feat: Add Maven release action with version bumping and dependency management
[borislavr](https://github.com/Netcracker/qubership-workflow-hub/commit/f484e81feb870af7eaea69c7b70c28383f70c0e9) fix: Update Maven release action to use input for GPG passphrase
[borislavr](https://github.com/Netcracker/qubership-workflow-hub/commit/28f9a5e56007263eecfe2c7af68da1bc7961fc10) chore: Remove commented-out environment variable settings in Maven release action
[borislavr](https://github.com/Netcracker/qubership-workflow-hub/commit/1de7582c9b9345832a3887c5872dca842512dc8a) fix: Update Git configuration in Maven release action to use bot identity
[borislavr](https://github.com/Netcracker/qubership-workflow-hub/commit/7f109e3635fd601331a952aa9464783d4a1a5410) feat: Add input for branch reference in Maven release action
[borislavr](https://github.com/Netcracker/qubership-workflow-hub/commit/5b9f980481e1db25177b02e58b848a88a26f877a) feat: Add maven-user and maven-password inputs for Maven release action
[borislavr](https://github.com/Netcracker/qubership-workflow-hub/commit/3b19491af7d94c20f1e836580856a2d0da99d542) fix: Correct echo statements and ensure PROFILE_ARG is used in Maven commands
[borislavr](https://github.com/Netcracker/qubership-workflow-hub/commit/50be35f7581301710b86a385f67ca4a8ecc9bb71) fix: Correct typo in dry-run failure message in bump_version_and_build function
[borislavr](https://github.com/Netcracker/qubership-workflow-hub/commit/7cfba5d423ae62396ad085ce59e40088747139bc) fix: Correct author name and email in commit-and-push action and tag-creator workflow
[borislavr](https://github.com/Netcracker/qubership-workflow-hub/commit/5684188de82b8401aabdd9a73fed9defed89632c) chore: Chdnged syntax for BASH & MARKDOWN linters
[borislavr](https://github.com/Netcracker/qubership-workflow-hub/commit/3e4d79d7a6884f0d5db546071462a6628964de12) fix: Add shellcheck disable comments for mvn deploy commands in bump_version_and_build and bump_dependencies_versions functions
[borislavr](https://github.com/Netcracker/qubership-workflow-hub/commit/4afd656295f495f8d973d5aab27eefcfcb488ef9) fix: Add shellcheck disable comments for error checks in bump_version_and_build and bump_dependencies_versions functions
<!-- end messages -->









