### PR TITLE
feat: Implement GhCommand class and update action inputs

### DIFF
--- a/actions/pr-assigner/README.md
+++ b/actions/pr-assigner/README.md
@@ -12,7 +12,7 @@ This **PR Assigner** GitHub Action automatically assigns a pull request to users
 | Name                  | Description                                      | Required | Default                          |
 | --------------------- | ------------------------------------------------ | -------- | -------------------------------- |
 | `configuration-path`  | Path to the configuration file.                  | No       | `.github/pr-assigner-config.yml` |
-| `assignees-count`     | Number of assignees to assign.                   | No       | `1`                              |
+| `shuffle`             | Number of assignees to assign.                   | No       | `1`                              |
 
 ## Usage Example
 
@@ -40,7 +40,7 @@ jobs:
         uses: netcracker/qubership-workflow-hub/actions/pr-assigner@main
         with:
           configuration-path: ".github/pr-assigner-config.yml"
-          assignees-count: 2
+          shuffle: 2
 ```
 
 ## Configuration File

--- a/actions/pr-assigner/action.yml
+++ b/actions/pr-assigner/action.yml
@@ -12,7 +12,7 @@ inputs:
         description: "Path to the configuration file."
         required: false
     assignees-count:
-        description: "count"
+        description: "DEPRECETED count"
         required: false
 runs:
   using: "node20"

--- a/actions/pr-assigner/action.yml
+++ b/actions/pr-assigner/action.yml
@@ -1,12 +1,19 @@
 name: "PR Assigner"
 description: "Assigns a PR to a user based on the PR configuration or CODEOWNERS."
 inputs:
+    assignees:
+        description: "List of assignees to assign the PR to."
+        required: false
+    shuffle:
+        description: "Number of assignees to assign."
+        default: '1'
+        required: false
     configuration-path:
         description: "Path to the configuration file."
         required: false
     assignees-count:
         description: "count"
-        requried: false    
+        required: false
 runs:
   using: "node20"
   main: "dist/index.js"

--- a/actions/pr-assigner/config.schema.json
+++ b/actions/pr-assigner/config.schema.json
@@ -13,6 +13,10 @@
         "count": {
             "type": "integer",
             "minimum": 1
+        },
+        "shuffle": {
+            "type": "integer",
+            "minimum": 1
         }
     },
     "required": [

--- a/actions/pr-assigner/dist/config.schema.json
+++ b/actions/pr-assigner/dist/config.schema.json
@@ -13,6 +13,10 @@
         "count": {
             "type": "integer",
             "minimum": 1
+        },
+        "shuffle": {
+            "type": "integer",
+            "minimum": 1
         }
     },
     "required": [

--- a/actions/pr-assigner/src/command.js
+++ b/actions/pr-assigner/src/command.js
@@ -1,0 +1,17 @@
+const { execSync } = require("child_process");
+
+class GhCommand {
+    constructor() {
+    }
+    getAssigneesCommand(prNumber) {
+        let cmd = `gh pr view ${prNumber} --json assignees --jq ".assignees | map(.login) | join(\\" \\" )"`;
+        return execSync(cmd).toString().trim();
+    }
+
+    addAssigneesCommand(prNumber, assignees) {
+        let cmd = `gh pr edit ${prNumber} ${assignees.map(user => `--add-assignee ${user}`).join(' ')}`;
+        return  execSync(cmd);
+    }
+}
+
+module.exports = GhCommand;

--- a/actions/pr-assigner/src/index.js
+++ b/actions/pr-assigner/src/index.js
@@ -3,7 +3,7 @@ const github = require("@actions/github");
 const fs = require("fs");
 const path = require("path");
 const ConfigLoader = require("./loader");
-const { execSync } = require("child_process");
+const GhCommand = require("./command");
 
 function findFile(filename, startDir = process.cwd()) {
     let dir = startDir;
@@ -18,14 +18,14 @@ function findFile(filename, startDir = process.cwd()) {
 }
 
 function getUsersFromCodeowners(codeownersPath) {
-    if (!codeownersPath) {
-        core.setFailed(`❗️ Can't find CODEOWNERS file.`);
-        return;
-    }
     core.info(`🔍 CODEOWNERS file found on: ${codeownersPath}`);
     const codeownersContent = fs.readFileSync(codeownersPath, 'utf8');
     const lines = codeownersContent.split('\n');
     const userLine = lines.find(line => line.trim().startsWith('*'));
+    if (!userLine) {
+        core.warning(`❗️ No user found in CODEOWNERS file`);
+        return null;
+    }
     return userLine.split(/\s+/).slice(1).filter(user => user.trim() !== '').map(user => user.replace('@', ''));
 }
 
@@ -48,29 +48,30 @@ async function run() {
     const defaultConfigurationPath = ".github/pr-assigner-config.yml";
     const configurationPath = core.getInput("configuration-path") || defaultConfigurationPath;
 
-    let count = core.getInput("assignees-count") || 1;
+    let count = core.getInput("shuffle");
+    // core.info(`Input shuffle: ${count}`);
     let assignees = [];
 
+    let sourceUsed = "CODEOWNERS file";
     if (fs.existsSync(configurationPath)) {
         const content = new ConfigLoader().load(configurationPath);
         assignees = content['assignees'];
         count = content['count'] != null ? content['count'] : count;
+        sourceUsed = `configuration file: ${configurationPath}`;
 
-        core.info(`🔹 Count for shuffle: ${count}`);
-        core.info(`🔹 Assignees: ${assignees}`);
-
-        core.warning(`Using configuration file ${configurationPath}`);
     } else {
         const codeownersPath = findFile('CODEOWNERS');
-        assignees = getUsersFromCodeowners(codeownersPath);
-        if (assignees == null) {
-            core.setFailed(`❗️ Can't process CODEOWNERS file`);
+        if (!codeownersPath) {
+            core.setFailed(`❗️ Can't find CODEOWNERS file.`);
             return;
         }
-        core.info(`🔹 Count for shuffle: ${count}`);
-        core.info(`🔹 Assignees: ${assignees}`);
-        core.warning(`Using CODEOWNERS file`);
+        assignees = getUsersFromCodeowners(codeownersPath);
     }
+
+    core.info(`🔹 Count for shuffle: ${count}`);
+    core.info(`🔹 Assignees: ${assignees}`);
+    core.info(`💡 Source used: ${sourceUsed}`);
+
 
     const assigneesLength = assignees.length;
     if (count > assigneesLength) {
@@ -85,17 +86,16 @@ async function run() {
     assignees = assignees.slice(0, count);
 
     try {
-
-        const getAssigneesCmd = `gh pr view ${pullRequest.number} --json assignees --jq ".assignees | map(.login) | join(\\" \\" )"`;
-        let currentAssignees = execSync(getAssigneesCmd).toString().trim();
-
-        if (currentAssignees != "") {
-            core.info(`💡✔️ PR has current assignees: ${currentAssignees}, skipping...`);
+        const ghCommand = new GhCommand();
+        let currentAssignees = ghCommand.getAssigneesCommand(pullRequest.number);
+        // core.info(`🔍 Current assignees: ${currentAssignees}`);
+        if (currentAssignees != null && currentAssignees != "" ) {
+            core.info(`✔️ PR has current assignees: ${currentAssignees}, skipping...`);
             return;
         }
-        const addCmd = `gh pr edit ${pullRequest.number} ${assignees.map(user => `--add-assignee ${user}`).join(' ')}`;
-        core.info(`💡 Adding new assignees with: ${addCmd}`);
-        execSync(addCmd, { stdio: 'inherit' });
+
+        core.info(`🟡 Adding new assignees with: ${assignees}`);
+        ghCommand.addAssigneesCommand(pullRequest.number, assignees);
 
         core.info("✔️ Action completed successfully!");
     } catch (error) {


### PR DESCRIPTION
feat:  Introduce the GhCommand class for managing GitHub PR assignees and correct input descriptions in action.yml. Update the 'assignees-count' input to 'shuffle' and mark the former as deprecated.
<!-- start messages -->
### Commit messages:
[nookyo](https://github.com/Netcracker/qubership-workflow-hub/commit/6de8c0f6cc475da5be0b77dcb75f59329a1164c0) feat: Implement GhCommand class for managing GitHub PR assignees
[nookyo](https://github.com/Netcracker/qubership-workflow-hub/commit/79de86400d144d118baf41a39f9f92ed0e7bedaa) fix: Correct 'required' typo and adjust input descriptions in action.yml
[nookyo](https://github.com/Netcracker/qubership-workflow-hub/commit/724c5cabfd1081e8e4922eb9f4449f6795b48573) fix: Update 'assignees-count' description to indicate deprecation
<!-- end messages -->
