### PR TITLE
fix: Add validation for templates in findTemplate function

### DIFF
--- a/actions/metadata-action/dist/index.js
+++ b/actions/metadata-action/dist/index.js
@@ -42797,6 +42797,7 @@ function matchesPattern(refName, pattern) {
 }
 
 function findTemplate(refName, templates) {
+  if (!Array.isArray(templates) || templates.length === 0) return null;
   for (let item of templates) {
     let pattern = Object.keys(item)[0];
     if (matchesPattern(refName, pattern)) {

--- a/actions/metadata-action/src/index.js
+++ b/actions/metadata-action/src/index.js
@@ -37,6 +37,7 @@ function matchesPattern(refName, pattern) {
 }
 
 function findTemplate(refName, templates) {
+  if (!Array.isArray(templates) || templates.length === 0) return null;
   for (let item of templates) {
     let pattern = Object.keys(item)[0];
     if (matchesPattern(refName, pattern)) {


### PR DESCRIPTION
fix: Implement validation to ensure that the templates parameter is an array and not empty in the findTemplate function.