### PR TITLE
feat: add compression level input for asset archiving

### DIFF
--- a/actions/assets-action/action.yml
+++ b/actions/assets-action/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: "Type of archive to create (zip, tar, etc.)"
     required: false
     default: "zip"
+  compression-level:
+    description: "Compression level for the archive (0-9)"
+    required: false
+    default: "9"
   retries:
     description: "How many times to retry upload on failure"
     required: false

--- a/actions/assets-action/dist/index.js
+++ b/actions/assets-action/dist/index.js
@@ -61871,7 +61871,7 @@ const path = __nccwpck_require__(6928);
 const archiver = __nccwpck_require__(1291);
 
 
-async function addToArchive(itemPath, archiveType) {
+async function addToArchive(itemPath, archiveType, compressionLevel) {
 
     const stat = await fs.promises.stat(itemPath);
     if (!stat.isDirectory()) {
@@ -61882,7 +61882,7 @@ async function addToArchive(itemPath, archiveType) {
     const archivePath = path.join(path.dirname(itemPath), archiveName);
 
     const output = fs.createWriteStream(archivePath);
-    const archive = archiver(archiveType, { zlib: { level: 9 } });
+    const archive = archiver(archiveType, { zlib: { level: compressionLevel } });
 
     const archiveClosed = new Promise((resolve, reject) => {
         output.on("close", () => {
@@ -72257,7 +72257,8 @@ async function getInput() {
     retries: parseInt(core.getInput("retries"), 10) || 3,
     delay: parseInt(core.getInput("retry-delay-ms"), 10) || 1000,
     factor: parseFloat(core.getInput("factor")) || 1,
-    dryRun: core.getInput("dry-run") === "true"
+    dryRun: core.getInput("dry-run") === "true",
+    compressionLevel: parseInt(core.getInput("compression-level"), 10) || 9
   };
 }
 
@@ -72346,7 +72347,7 @@ async function run() {
 
       if (fs.statSync(itemPath).isDirectory()) {
         try {
-          archivePath = await addToArchive(itemPath, input.archiveType);
+          archivePath = await addToArchive(itemPath, input.archiveType, input.compressionLevel);
 
         } catch (archiveErr) {
           core.error(`Error packaging ${itemPath}: ${archiveErr.message}`);

--- a/actions/assets-action/src/archiveUtils.js
+++ b/actions/assets-action/src/archiveUtils.js
@@ -4,7 +4,7 @@ const path = require("path");
 const archiver = require("archiver");
 
 
-async function addToArchive(itemPath, archiveType) {
+async function addToArchive(itemPath, archiveType, compressionLevel) {
 
     const stat = await fs.promises.stat(itemPath);
     if (!stat.isDirectory()) {
@@ -15,7 +15,7 @@ async function addToArchive(itemPath, archiveType) {
     const archivePath = path.join(path.dirname(itemPath), archiveName);
 
     const output = fs.createWriteStream(archivePath);
-    const archive = archiver(archiveType, { zlib: { level: 9 } });
+    const archive = archiver(archiveType, { zlib: { level: compressionLevel } });
 
     const archiveClosed = new Promise((resolve, reject) => {
         output.on("close", () => {

--- a/actions/assets-action/src/index.js
+++ b/actions/assets-action/src/index.js
@@ -19,7 +19,8 @@ async function getInput() {
     retries: parseInt(core.getInput("retries"), 10) || 3,
     delay: parseInt(core.getInput("retry-delay-ms"), 10) || 1000,
     factor: parseFloat(core.getInput("factor")) || 1,
-    dryRun: core.getInput("dry-run") === "true"
+    dryRun: core.getInput("dry-run") === "true",
+    compressionLevel: parseInt(core.getInput("compression-level"), 10) || 9
   };
 }
 
@@ -108,7 +109,7 @@ async function run() {
 
       if (fs.statSync(itemPath).isDirectory()) {
         try {
-          archivePath = await addToArchive(itemPath, input.archiveType);
+          archivePath = await addToArchive(itemPath, input.archiveType, input.compressionLevel);
 
         } catch (archiveErr) {
           core.error(`Error packaging ${itemPath}: ${archiveErr.message}`);


### PR DESCRIPTION
feat: add compression level input for asset archiving
#219 

Add compression level for achive (0-9)

compression-level:
description: "Compression level for the archive (0-9)"
required: false
default: "9"