### PR TITLE
bug: Bug/issues 221 [tag-action] Cant force create tag [rejected]

### DIFF
--- a/actions/tag-action/action.yml
+++ b/actions/tag-action/action.yml
@@ -93,3 +93,4 @@ runs:
           echo "✅ Tag '${{ inputs.tag-name }}' pushed."
         fi
         echo "created-tag=${{ inputs.tag-name }}" >> $GITHUB_OUTPUT
+

--- a/actions/tag-action/action.yml
+++ b/actions/tag-action/action.yml
@@ -78,8 +78,11 @@ runs:
       shell: bash
       run: |
         if [ "${{ inputs.force-create }}" == "true" ] && [ "$(git tag -l "${{ inputs.tag-name }}")" ]; then
-          echo "🔄 Force create enabled: Deleting existing tag '${{ inputs.tag-name }}'"
+          echo "🔄 Force create enabled: Deleting existing tag '${{ inputs.tag-name }}' locally and remotely"
           git tag -d "${{ inputs.tag-name }}"
+          if [ "${{ inputs.dry-run }}" != "true" ]; then
+            git push origin --delete "${{ inputs.tag-name }}"
+          fi
         fi
         echo "💡 Trying to create tag: '${{ inputs.tag-name }}'"
         git tag -a "${{ inputs.tag-name }}" -m "${{ inputs.tag-message }}"


### PR DESCRIPTION
bug: This pull request updates the `actions/tag-action/action.yml` file to enhance the tag creation process by improving clarity in logging and adding a safeguard for remote tag deletion. 

Improvements to tag creation process:

* Updated the log message to clarify that the tag is being deleted both locally and remotely when force-create is enabled.
* Added a conditional check to ensure that remote tag deletion only occurs if the `dry-run` input is not set to `true`. This prevents unintended changes during testing.

Minor changes:

* Added a blank line for formatting consistency at the end of the `runs:` section.

https://github.com/Netcracker/qubership-workflow-hub/pull/222