### PR TITLE
feat: Feature/issue 223

### DIFF
--- a/actions/tag-action/action.yml
+++ b/actions/tag-action/action.yml
@@ -26,7 +26,7 @@ inputs:
   switch-to-tag:
     description: "Switch to the created tag after creation."
     required: false
-    default: "true"
+    default: "false"
   tag-message:
     description: "Tag creation message."
     required: false
@@ -103,10 +103,10 @@ runs:
         echo "created-tag=${{ inputs.tag-name }}" >> $GITHUB_OUTPUT
 
     - name: Check if tag was create
-      if: ${{ inputs.tag-name !== '' && inputs.create-release == 'true' && inputs.dry-run != 'true' }}
+      if: ${{ inputs.tag-name != '' && inputs.create-release == 'true' && inputs.dry-run != 'true' }}
       shell: bash
       run: |
-        TAG_NAME="${{ inputs.tag }}"
+        TAG_NAME="${{ inputs.tag-name }}"
         RELEASE_TITLE="$TAG_NAME"
         RELEASE_BODY="Automatically generated release for tag $TAG_NAME."
 
@@ -119,12 +119,12 @@ runs:
           echo "🚀 Release $TAG_NAME does not exist. Creating it..."
           gh release create "$TAG_NAME" --title "$RELEASE_TITLE" --notes "$RELEASE_BODY"
         fi
-        echo "✅ Release $TAG_NAME has been created or updated successfully.
+        echo "✅ Release $TAG_NAME has been created or updated successfully."
 
     - name: Switch to tag
       if: ${{ inputs.switch-to-tag == 'true' &&  inputs.create-tag == 'true' && inputs.dry-run != 'true' }}
       shell: bash
       run: |
         git fetch --tags
-        git checkout tags/${{ inputs.tag }}
-        echo "Switched to tag '${{ inputs.tag-name }}'"
+        git checkout tags/${{ inputs.tag-name }}
+        echo "💡 Switched to tag ${{ inputs.tag-name }}"


### PR DESCRIPTION
feat:  This pull request enhances the functionality of the `actions/tag-action` GitHub Action by introducing new input options and corresponding logic to handle GitHub releases and tag switching. The most important changes include adding new inputs to the action configuration and implementing steps to create or update releases and switch to created tags.

### Enhancements to action configuration:

* [`actions/tag-action/action.yml`](diffhunk://#diff-47e71ba6dde840275e694600bbdc454edf6171d758e5dc621fb59060dd2f404cR26-R37): Added new inputs `switch-to-tag` and `create-release` to allow switching to a created tag and creating a GitHub release for the tag, respectively. Both inputs are optional and default to `"false"`.

### New functionality:

* [`actions/tag-action/action.yml`](diffhunk://#diff-47e71ba6dde840275e694600bbdc454edf6171d758e5dc621fb59060dd2f404cR105-R130): Added a step to check if a release for the specified tag exists. If it does, the release is updated; otherwise, a new release is created. This step is conditional on `create-release` being `"true"`, `tag-name` being non-empty, and `dry-run` being `"false"`.
* [`actions/tag-action/action.yml`](diffhunk://#diff-47e71ba6dde840275e694600bbdc454edf6171d758e5dc621fb59060dd2f404cR105-R130): Added a step to switch to the created tag after its creation. This step is conditional on `switch-to-tag` being `"true"`, `create-tag` being `"true"`, and `dry-run` being `"false"`.