### PR TITLE
chore: Add ability to create or update GitHub release with tag name

### DIFF
--- a/actions/tag-action/action.yml
+++ b/actions/tag-action/action.yml
@@ -117,7 +117,7 @@ runs:
           gh release edit "$TAG_NAME"  --title "$RELEASE_TITLE" --notes "$RELEASE_BODY"
         else
           echo "🚀 Release $TAG_NAME does not exist. Creating it..."
-          gh release create "$TAG_NAME" --title "$RELEASE_TITLE" --notes "$RELEASE_BODY"
+          gh release create "$TAG_NAME" --title "$RELEASE_TITLE" --notes "$RELEASE_BODY"  --draft=false --latest
         fi
         echo "✅ Release $TAG_NAME has been created or updated successfully."
 


### PR DESCRIPTION
chore: This update allows the creation of a GitHub release with the tag name as the release name, ensuring the release is marked as non-draft and set as the latest if it does not already exist.

Fixes #223