### PR TITLE
fix: `build-args` in docker-action

### DIFF
--- a/actions/docker-action/action.yml
+++ b/actions/docker-action/action.yml
@@ -50,7 +50,7 @@ inputs:
     required: false
     default: "false"
   build-args:
-    description: "Build arguments for the Docker image, in JSON format."
+    description: "Build arguments for the Docker image."
     required: false
     default: ""
   security-scan:
@@ -185,7 +185,7 @@ runs:
         tags: ${{ inputs.tags != '' && steps.prepare-tags.outputs.prepared_tags || steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         platforms: ${{ inputs.platforms }}
-        build-args: ${{ inputs.build-args != ''}}
+        build-args: ${{ inputs.build-args }}
 
     - name: Output result
       shell: bash

--- a/actions/docker-action/action.yml
+++ b/actions/docker-action/action.yml
@@ -50,7 +50,7 @@ inputs:
     required: false
     default: "false"
   build-args:
-    description: "Build arguments for the Docker image."
+    description: "Build arguments for the Docker image, in List format."
     required: false
     default: ""
   security-scan:

--- a/actions/docker-action/action.yml
+++ b/actions/docker-action/action.yml
@@ -50,7 +50,7 @@ inputs:
     required: false
     default: "false"
   build-args:
-    description: "Build arguments for the Docker image, in List format."
+    description: "List of build-time variables"
     required: false
     default: ""
   security-scan:


### PR DESCRIPTION
This PR updates the build-args parameter passed to docker/build-push-action@v6 so that it correctly uses the input value provided to the composite action.

Previously, the step was written as:
`build-args: ${{ inputs.build-args != '' }}`

This evaluates to a boolean (true or false) instead of the intended build arguments. While harmless if unused, it meant that even when build arguments were passed, they were not being forwarded to the Docker build process.

With this change, the step now directly references the input:
`build-args: ${{ inputs.build-args }}`

This ensures that, if no build arguments are provided, the default empty string ("") is used and no --build-arg flags are passed.

If build arguments are provided in KEY=VALUE format (one per line), they are passed through to docker/build-push-action as intended.

Changes:

Restores expected functionality when using build arguments.

No behavior change for workflows that do not set build-args.

Keeps input handling consistent with other parameters in the action.

### Fixes
Closes: [#296 ](https://github.com/Netcracker/qubership-workflow-hub/issues/296)
