### PR TITLE
fix: Build-args input handling in action.yml

### DIFF
--- a/actions/docker-action/action.yml
+++ b/actions/docker-action/action.yml
@@ -185,7 +185,7 @@ runs:
         tags: ${{ inputs.tags != '' && steps.prepare-tags.outputs.prepared_tags || steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         platforms: ${{ inputs.platforms }}
-        build-args: ${{ inputs.build-args != ''}}
+        build-args: ${{ inputs.build-args }}
 
     - name: Output result
       shell: bash


### PR DESCRIPTION
Correct the handling of the `build-args` input to ensure it passes the intended value instead of a boolean.