### PR TITLE
feat: maven artifact group name restrictions

### DIFF
--- a/actions/maven-release/action.yaml
+++ b/actions/maven-release/action.yaml
@@ -142,7 +142,7 @@ runs:
           else
             echo "OK: $pom => $gid"
           fi
-        done <<(find . -name pom.xml -type f -not -path "*/target/*" | sort)
+        done <<< $(find . -name pom.xml -type f -not -path "*/target/*" | sort)
         exit $viol
     - name: "Release"
       id: release


### PR DESCRIPTION
# Pull Request

## Summary
It will not be possible to build and publish maven artifacts with group id == `org.qubership`

## Issue
#315 
## Breaking Change?
- [X] Yes
- [ ] No
Maven based projects must adjust their atifacts group id in pom.xml

## Scope / Project
`actions`, `maven`

## Implementation Notes
It will not be possible to build and publish maven artifacts with group id == `org.qubership`

## Tests / Evidence
https://github.com/MyBorislavrOrg/qubership-integration-engine-1/actions/runs/17236681241/job/48903203050
<img width="746" height="168" alt="image" src="https://github.com/user-attachments/assets/fb8fedb5-2710-4f0a-8891-8ff3b8b2a661" />

