### PR TITLE
feat: charts-values-update-action can optionally publish charts to ghcr.io

### DIFF
--- a/actions/charts-values-update-action/README.md
+++ b/actions/charts-values-update-action/README.md
@@ -41,6 +41,16 @@ In that case the action will find the latest tag of an image which satisfy the r
 **Optional**  
 The working directory for the action. Defaults to `.`. Used in specific cases, in testing CI workflows mostly.
 
+### `package-charts`
+
+**Optional**  
+Pckage charts using `helm package` command. Defaults to `false`.
+
+### `publish-charts`
+
+**Optional**  
+Publish helm charts to the `ghcr.io` registry using `oci://ghcr.io/${{ github.repository }}/` command. Defaults to `false`.
+
 ## Environment
 
 ### `GITHUB_TOKEN`
@@ -66,6 +76,21 @@ The updated image versions in JSON format.
 "qubership-zookeeper-monitoring": "1.1.8",
 "qubership-zookeeper-backup-daemon": "1.1.8",
 "qubership-zookeeper-integration-tests": "1.1.8-3.8.4"
+}
+```
+
+### `chart-metadata`
+
+Charts metadata in JSON format.
+
+```json
+{
+    "appVersion": "2.10.0",
+    "mime-type": "application/vnd.qubership.helm.chart",
+    "name": "qubership-jaeger",
+    "reference": "oci://ghcr.io/netcracker/qubership-jaeger/qubership-jaeger:0.0.8",
+    "type": "application",
+    "version": "0.0.8"
 }
 ```
 

--- a/actions/charts-values-update-action/action.yaml
+++ b/actions/charts-values-update-action/action.yaml
@@ -182,5 +182,5 @@ runs:
     - name: Upload charts meta
       uses: actions/upload-artifact@v4
       with:
-        name: charts-meta
+        name: charts-meta.json
         path: "./charts_meta/*.json"

--- a/actions/charts-values-update-action/action.yaml
+++ b/actions/charts-values-update-action/action.yaml
@@ -149,7 +149,7 @@ runs:
       run: |
         echo '${{ github.token }}' | helm registry login -u '${{ github.repository_owner }}' --password-stdin 'ghcr.io'
         for chart in ${{ github.workspace }}/.cr-release-packages/*.tgz; do
-          helm push ${chart} oci://ghcr.io/${{ github.repository_owner }}/
+          helm push ${chart} oci://ghcr.io/${{ github.repository }}/
         done
         helm registry logout 'ghcr.io'
       shell: bash
@@ -165,7 +165,7 @@ runs:
           chart_version=$(helm show chart ${chart} | grep "version: " | sed "s#^\s*version:\s*##" | tr -d '\r')
           chart_app_version=$(helm show chart ${chart} | grep "appVersion: " | sed "s#^\s*appVersion:\s*##" | tr -d '\r')
           if [[ ${{ inputs.publish-charts }} == 'true' ]]; then
-            chart_meta="{\"name\":\"${chart_name}\",\"version\":\"${chart_version}\",\"appVersion\":\"${chart_app_version}\",\"type\":\"application\",\"mime-type\":\"application/vnd.qubership.helm.chart\",\"reference\":\"oci://ghcr.io/${{ github.repository_owner }}/${chart_name}:${chart_version}\"}"
+            chart_meta="{\"name\":\"${chart_name}\",\"version\":\"${chart_version}\",\"appVersion\":\"${chart_app_version}\",\"type\":\"application\",\"mime-type\":\"application/vnd.qubership.helm.chart\",\"reference\":\"oci://ghcr.io/${{ github.repository }}/${chart_name}:${chart_version}\"}"
           else
             chart_meta="{\"name\":\"${chart_name}\",\"version\":\"${chart_version}\",\"appVersion\":\"${chart_app_version}\",\"type\":\"application\",\"mime-type\":\"application/vnd.qubership.helm.chart\"}"
           fi

--- a/actions/charts-values-update-action/action.yaml
+++ b/actions/charts-values-update-action/action.yaml
@@ -150,7 +150,7 @@ runs:
         echo '${{ github.token }}' | helm registry login -u '${{ github.repository_owner }}' --password-stdin 'ghcr.io'
         for chart in ${{ github.workspace }}/.cr-release-packages/*.tgz; do
           #chart_name=$(basename ${chart} | sed 's/\.yaml$//')
-          helm push ${chart} oci:://ghcr.io/${{ github.repository_owner }}/
+          helm push ${chart} oci:://ghcr.io/${{ github.repository }}/
         done
         helm registry logout 'ghcr.io'
       shell: bash

--- a/actions/charts-values-update-action/action.yaml
+++ b/actions/charts-values-update-action/action.yaml
@@ -136,7 +136,7 @@ runs:
     - name: "Package helm charts"
       if: ${{ inputs.package-charts == 'true' }}
       run: |
-        charts=$(grep "chart_file: " ${{ inputs.config-file }} | sed "s#^\s*chart_file:\s*##" | dirname)
+        charts=$(grep "chart_file: " ${{ inputs.config-file }} | sed "s#^\s*chart_file:\s*##" | xargs dirname)
         for chart in ${charts}; do
           echo "Packaging chart: ${chart}"
           helm package ${chart} --destination ${{ github.workspace }}/.cr-release-packages

--- a/actions/charts-values-update-action/action.yaml
+++ b/actions/charts-values-update-action/action.yaml
@@ -146,7 +146,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}
 
     - name: "Publish helm charts"
-      if: ${{ inputs.publish-charts == 'true' }}
+      if: ${{ inputs.package-charts == 'true' && inputs.publish-charts == 'true' }}
       run: |
         echo '${{ github.token }}' | helm registry login -u '${{ github.repository_owner }}' --password-stdin 'ghcr.io'
         for chart in ${{ github.workspace }}/.cr-release-packages/*.tgz; do
@@ -181,6 +181,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
     - name: Upload charts meta
+      if: ${{ inputs.package-charts == 'true' && inputs.publish-charts == 'true' }}
       uses: actions/upload-artifact@v4
       with:
         name: charts-meta.json

--- a/actions/charts-values-update-action/action.yaml
+++ b/actions/charts-values-update-action/action.yaml
@@ -166,7 +166,7 @@ runs:
           chart_version=$(helm show chart ${chart} | grep "version: " | sed "s#^\s*version:\s*##" | tr -d '\r')
           chart_app_version=$(helm show chart ${chart} | grep "appVersion: " | sed "s#^\s*appVersion:\s*##" | tr -d '\r')
           if [[ ${{ inputs.publish-charts }} == 'true' ]]; then
-            chart_meta="{\"name\":\"${chart_name}\",\"version\":\"${chart_version}\",\"appVersion\":\"${chart_app_version}\",\"type\":\"application\",\"mime-type\":\"application/vnd.qubership.helm.chart\",\"purl\":\"ghcr.io/${{ github.repository_owner }}/${chart_name}-${{ inputs.release-version }}.tgz\"}"
+            chart_meta="{\"name\":\"${chart_name}\",\"version\":\"${chart_version}\",\"appVersion\":\"${chart_app_version}\",\"type\":\"application\",\"mime-type\":\"application/vnd.qubership.helm.chart\",\"purl\":\"ghcr.io/${{ github.repository_owner }}/${chart_name}-${chart_version}.tgz\"}"
           else
             chart_meta="{\"name\":\"${chart_name}\",\"version\":\"${chart_version}\",\"appVersion\":\"${chart_app_version}\",\"type\":\"application\",\"mime-type\":\"application/vnd.qubership.helm.chart\"}"
           fi

--- a/actions/charts-values-update-action/action.yaml
+++ b/actions/charts-values-update-action/action.yaml
@@ -180,7 +180,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
     - name: Upload charts meta
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v4
       with:
         name: charts-meta
         path: "./charts_meta/*.json"

--- a/actions/charts-values-update-action/action.yaml
+++ b/actions/charts-values-update-action/action.yaml
@@ -150,7 +150,7 @@ runs:
         echo '${{ github.token }}' | helm registry login -u '${{ github.repository_owner }}' --password-stdin 'ghcr.io'
         for chart in ${{ github.workspace }}/.cr-release-packages/*.tgz; do
           #chart_name=$(basename ${chart} | sed 's/\.yaml$//')
-          helm push ${chart} oci:://ghcr.io/${{ github.repository }}/
+          helm push ${chart} oci://ghcr.io/${{ github.repository }}/
         done
         helm registry logout 'ghcr.io'
       shell: bash

--- a/actions/charts-values-update-action/action.yaml
+++ b/actions/charts-values-update-action/action.yaml
@@ -1,6 +1,6 @@
 ---
 
-name: "Charts Release"
+name: "Charts Values Update Action"
 description: "Update helm charts versions in values.yaml file and create a release draft"
 
 inputs:
@@ -33,10 +33,23 @@ inputs:
     required: false
     default: "."
     type: string
+  package-charts:
+    description: "Package helm charts after updating versions"
+    required: false
+    default: "false"
+    type: string
+  publish-charts:
+    description: "Publish helm charts to the ghcr registry"
+    required: false
+    default: "false"
+    type: string
 outputs:
   images-versions:
     description: "Image versions updated in the values.yaml file"
     value: ${{ steps.update-versions.outputs.images-versions }}
+  chart-metadata:
+    description: "Chart metadata"
+    value: ${{ steps.metadata.outputs.chart-metadata }}
 runs:
   using: "composite"
   steps:
@@ -67,7 +80,7 @@ runs:
             exit 1
           fi
         done
-       
+
     - name: "Create release branch"
       if: ${{ inputs.create-release-branch == 'true' }}
       id: create-release-branch
@@ -114,5 +127,55 @@ runs:
         git add .
         git commit -m "release: Set chart and images versions to release ${{ inputs.release-version }}. [skip ci]"
         git push
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+
+    - name: "Configure helm"
+      uses: azure/setup-helm@v4.3.0
+
+    - name: "Package helm charts"
+      if: ${{ inputs.package-charts == 'true' }}
+      run: |
+        charts=$(grep "chart_file: " ${{ inputs.config-file }} | sed "s#^\s*chart_file:\s*##" | dirname)
+        for chart in ${charts}; do
+          echo "Packaging chart: ${chart}"
+          helm package ${chart} --destination ${{ github.workspace }}/.cr-release-packages
+        done
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+
+    - name: "Publish helm charts"
+      if: ${{ inputs.publish-charts == 'true' }}
+      run: |
+        echo '${{ github.token }}' | helm registry login -u '${{ github.repository_owner }}' --password-stdin 'ghcr.io'
+        for chart in ${{ github.workspace }}/.cr-release-packages/*.tgz; do
+          #chart_name=$(basename ${chart} | sed 's/\.yaml$//')
+          helm push ${chart} oci:://ghcr.io/${{ github.repository_owner }}/
+        done
+        helm registry logout 'ghcr.io'
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+
+    - name: "Get chart metadata"
+      if: ${{ inputs.package-charts == 'true' }}
+      id: metadata
+      run: |
+        charts_metadata=""
+        for chart in ${{ github.workspace }}/.cr-release-packages/*.tgz; do
+          chart_name=$(helm show chart ${chart} | grep "name: " | sed "s#^\s*name:\s*##" | tr -d '\r')
+          chart_version=$(helm show chart ${chart} | grep "version: " | sed "s#^\s*version:\s*##" | tr -d '\r')
+          chart_app_version=$(helm show chart ${chart} | grep "appVersion: " | sed "s#^\s*appVersion:\s*##" | tr -d '\r')
+          if [[ ${{ inputs.publish-charts }} == 'true' ]]; then
+            chart_meta="{\"name\":\"${chart_name}\",\"version\":\"${chart_version}\",\"appVersion\":\"${chart_app_version}\",\"type\":\"application\",\"mime-type\":\"application/vnd.qubership.helm.chart\",\"purl\":\"ghcr.io/${{ github.repository_owner }}/${chart_name}-${{ inputs.release-version }}.tgz\"}"
+          else
+            chart_meta="{\"name\":\"${chart_name}\",\"version\":\"${chart_version}\",\"appVersion\":\"${chart_app_version}\",\"type\":\"application\",\"mime-type\":\"application/vnd.qubership.helm.chart\"}"
+          fi
+          #chart_meta="{\"name\":\"${chart_name}\",\"version\":\"${chart_version}\",\"appVersion\":\"${chart_app_version}\",\"type\":\"application\",\"mime-type\":\"application/vnd.qubership.helm.chart\"}"
+          charts_metadata="${charts_metadata}${chart_meta},"
+        done
+        charts_metadata=${charts_metadata%,}  # Remove trailing comma
+        charts_metadata="{\"charts\":[${charts_metadata}]}"
+        echo "metadata=${charts_metadata}" >> $GITHUB_OUTPUT
+        echo "metadata=${charts_metadata}" >> $GITHUB_STEP_SUMMARY
       shell: bash
       working-directory: ${{ inputs.working-directory }}

--- a/actions/charts-values-update-action/action.yaml
+++ b/actions/charts-values-update-action/action.yaml
@@ -166,7 +166,7 @@ runs:
           chart_version=$(helm show chart ${chart} | grep "version: " | sed "s#^\s*version:\s*##" | tr -d '\r')
           chart_app_version=$(helm show chart ${chart} | grep "appVersion: " | sed "s#^\s*appVersion:\s*##" | tr -d '\r')
           if [[ ${{ inputs.publish-charts }} == 'true' ]]; then
-            chart_meta="{\"name\":\"${chart_name}\",\"version\":\"${chart_version}\",\"appVersion\":\"${chart_app_version}\",\"type\":\"application\",\"mime-type\":\"application/vnd.qubership.helm.chart\",\"purl\":\"ghcr.io/${{ github.repository_owner }}/${chart_name}-${chart_version}.tgz\"}"
+            chart_meta="{\"name\":\"${chart_name}\",\"version\":\"${chart_version}\",\"appVersion\":\"${chart_app_version}\",\"type\":\"application\",\"mime-type\":\"application/vnd.qubership.helm.chart\",\"purl\":\"ghcr.io/${{ github.repository }}/${chart_name}:${chart_version}\"}"
           else
             chart_meta="{\"name\":\"${chart_name}\",\"version\":\"${chart_version}\",\"appVersion\":\"${chart_app_version}\",\"type\":\"application\",\"mime-type\":\"application/vnd.qubership.helm.chart\"}"
           fi

--- a/actions/charts-values-update-action/action.yaml
+++ b/actions/charts-values-update-action/action.yaml
@@ -49,7 +49,7 @@ outputs:
     value: ${{ steps.update-versions.outputs.images-versions }}
   chart-metadata:
     description: "Chart metadata"
-    value: ${{ steps.metadata.outputs.chart-metadata }}
+    value: ${{ steps.metadata.outputs.metadata }}
 runs:
   using: "composite"
   steps:

--- a/actions/charts-values-update-action/action.yaml
+++ b/actions/charts-values-update-action/action.yaml
@@ -149,7 +149,6 @@ runs:
       run: |
         echo '${{ github.token }}' | helm registry login -u '${{ github.repository_owner }}' --password-stdin 'ghcr.io'
         for chart in ${{ github.workspace }}/.cr-release-packages/*.tgz; do
-          #chart_name=$(basename ${chart} | sed 's/\.yaml$//')
           helm push ${chart} oci://ghcr.io/${{ github.repository }}/
         done
         helm registry logout 'ghcr.io'
@@ -165,12 +164,14 @@ runs:
           chart_name=$(helm show chart ${chart} | grep "name: " | sed "s#^\s*name:\s*##" | tr -d '\r')
           chart_version=$(helm show chart ${chart} | grep "version: " | sed "s#^\s*version:\s*##" | tr -d '\r')
           chart_app_version=$(helm show chart ${chart} | grep "appVersion: " | sed "s#^\s*appVersion:\s*##" | tr -d '\r')
+          uuid=$(uuidgen)
+          # to lowercase 
+          uuid=${uuid,,}
           if [[ ${{ inputs.publish-charts }} == 'true' ]]; then
-            chart_meta="{\"name\":\"${chart_name}\",\"version\":\"${chart_version}\",\"appVersion\":\"${chart_app_version}\",\"type\":\"application\",\"mime-type\":\"application/vnd.qubership.helm.chart\",\"purl\":\"ghcr.io/${{ github.repository }}/${chart_name}:${chart_version}\"}"
+            chart_meta="{\"bom-ref\":\"${chart_name}:${uuid}\",\"name\":\"${chart_name}\",\"version\":\"${chart_version}\",\"appVersion\":\"${chart_app_version}\",\"type\":\"application\",\"mime-type\":\"application/vnd.qubership.helm.chart\",\"purl\":\"ghcr.io/${{ github.repository }}/${chart_name}:${chart_version}\"}"
           else
-            chart_meta="{\"name\":\"${chart_name}\",\"version\":\"${chart_version}\",\"appVersion\":\"${chart_app_version}\",\"type\":\"application\",\"mime-type\":\"application/vnd.qubership.helm.chart\"}"
+            chart_meta="{\"bom-ref\":\"${chart_name}:${uuid}\",\"name\":\"${chart_name}\",\"version\":\"${chart_version}\",\"appVersion\":\"${chart_app_version}\",\"type\":\"application\",\"mime-type\":\"application/vnd.qubership.helm.chart\"}"
           fi
-          #chart_meta="{\"name\":\"${chart_name}\",\"version\":\"${chart_version}\",\"appVersion\":\"${chart_app_version}\",\"type\":\"application\",\"mime-type\":\"application/vnd.qubership.helm.chart\"}"
           charts_metadata="${charts_metadata}${chart_meta},"
         done
         charts_metadata=${charts_metadata%,}  # Remove trailing comma

--- a/actions/charts-values-update-action/action.yaml
+++ b/actions/charts-values-update-action/action.yaml
@@ -149,7 +149,7 @@ runs:
       run: |
         echo '${{ github.token }}' | helm registry login -u '${{ github.repository_owner }}' --password-stdin 'ghcr.io'
         for chart in ${{ github.workspace }}/.cr-release-packages/*.tgz; do
-          helm push ${chart} oci://ghcr.io/${{ github.repository }}/
+          helm push ${chart} oci://ghcr.io/${{ github.repository_owner }}/
         done
         helm registry logout 'ghcr.io'
       shell: bash
@@ -168,10 +168,12 @@ runs:
           # to lowercase 
           uuid=${uuid,,}
           if [[ ${{ inputs.publish-charts }} == 'true' ]]; then
-            chart_meta="{\"bom-ref\":\"${chart_name}:${uuid}\",\"name\":\"${chart_name}\",\"version\":\"${chart_version}\",\"appVersion\":\"${chart_app_version}\",\"type\":\"application\",\"mime-type\":\"application/vnd.qubership.helm.chart\",\"purl\":\"ghcr.io/${{ github.repository }}/${chart_name}:${chart_version}\"}"
+            chart_meta="{\"bom-ref\":\"${chart_name}:${uuid}\",\"name\":\"${chart_name}\",\"version\":\"${chart_version}\",\"appVersion\":\"${chart_app_version}\",\"type\":\"application\",\"mime-type\":\"application/vnd.qubership.helm.chart\",\"reference\":\"oci://ghcr.io/${{ github.repository_owner }}/${chart_name}:${chart_version}\"}"
           else
             chart_meta="{\"bom-ref\":\"${chart_name}:${uuid}\",\"name\":\"${chart_name}\",\"version\":\"${chart_version}\",\"appVersion\":\"${chart_app_version}\",\"type\":\"application\",\"mime-type\":\"application/vnd.qubership.helm.chart\"}"
           fi
+          mkdir -p ./charts_meta
+          echo ${chart_meta} > ./charts_meta/${chart_name}-${chart_version}.json
           charts_metadata="${charts_metadata}${chart_meta},"
         done
         charts_metadata=${charts_metadata%,}  # Remove trailing comma
@@ -180,3 +182,8 @@ runs:
         echo "metadata=${charts_metadata}" >> $GITHUB_STEP_SUMMARY
       shell: bash
       working-directory: ${{ inputs.working-directory }}
+    - name: Upload charts meta
+      uses: actions/upload-artifact@v5
+      with:
+        name: charts-meta
+        path: "./charts_meta/*.json"

--- a/actions/charts-values-update-action/action.yaml
+++ b/actions/charts-values-update-action/action.yaml
@@ -164,13 +164,10 @@ runs:
           chart_name=$(helm show chart ${chart} | grep "name: " | sed "s#^\s*name:\s*##" | tr -d '\r')
           chart_version=$(helm show chart ${chart} | grep "version: " | sed "s#^\s*version:\s*##" | tr -d '\r')
           chart_app_version=$(helm show chart ${chart} | grep "appVersion: " | sed "s#^\s*appVersion:\s*##" | tr -d '\r')
-          uuid=$(uuidgen)
-          # to lowercase 
-          uuid=${uuid,,}
           if [[ ${{ inputs.publish-charts }} == 'true' ]]; then
-            chart_meta="{\"bom-ref\":\"${chart_name}:${uuid}\",\"name\":\"${chart_name}\",\"version\":\"${chart_version}\",\"appVersion\":\"${chart_app_version}\",\"type\":\"application\",\"mime-type\":\"application/vnd.qubership.helm.chart\",\"reference\":\"oci://ghcr.io/${{ github.repository_owner }}/${chart_name}:${chart_version}\"}"
+            chart_meta="{\"name\":\"${chart_name}\",\"version\":\"${chart_version}\",\"appVersion\":\"${chart_app_version}\",\"type\":\"application\",\"mime-type\":\"application/vnd.qubership.helm.chart\",\"reference\":\"oci://ghcr.io/${{ github.repository_owner }}/${chart_name}:${chart_version}\"}"
           else
-            chart_meta="{\"bom-ref\":\"${chart_name}:${uuid}\",\"name\":\"${chart_name}\",\"version\":\"${chart_version}\",\"appVersion\":\"${chart_app_version}\",\"type\":\"application\",\"mime-type\":\"application/vnd.qubership.helm.chart\"}"
+            chart_meta="{\"name\":\"${chart_name}\",\"version\":\"${chart_version}\",\"appVersion\":\"${chart_app_version}\",\"type\":\"application\",\"mime-type\":\"application/vnd.qubership.helm.chart\"}"
           fi
           mkdir -p ./charts_meta
           echo ${chart_meta} > ./charts_meta/${chart_name}-${chart_version}.json

--- a/actions/charts-values-update-action/action.yaml
+++ b/actions/charts-values-update-action/action.yaml
@@ -131,6 +131,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}
 
     - name: "Configure helm"
+      if: ${{ inputs.package-charts == 'true' || inputs.publish-charts == 'true' }}
       uses: azure/setup-helm@v4.3.0
 
     - name: "Package helm charts"
@@ -156,7 +157,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}
 
     - name: "Get chart metadata"
-      if: ${{ inputs.package-charts == 'true' }}
+      if: ${{ inputs.package-charts == 'true' && inputs.publish-charts == 'true' }}
       id: metadata
       run: |
         charts_metadata=""
@@ -183,4 +184,4 @@ runs:
       uses: actions/upload-artifact@v4
       with:
         name: charts-meta.json
-        path: "./charts_meta/*.json"
+        path: "${{ inputs.working-directory }}/charts_meta/*.json"

--- a/actions/charts-values-update-action/image-versions-replace.py
+++ b/actions/charts-values-update-action/image-versions-replace.py
@@ -46,7 +46,6 @@ def get_latest_version_by_regex(versions, pattern_str):
     except re.error as e:
         print(f"::error::Invalid regular expression '{pattern}': {str(e)}")
         sys.exit(1)
-        #raise ValueError(f"Incorrect regular expression: {str(e)}") from None
 
     matched_versions = []
 
@@ -67,15 +66,14 @@ def replace_tag_regexp(image_str, tag_re):
     # Try to find the requested tag for given image_str
     if tag_re.startswith("#"):
         try:
-            os.system(f"skopeo login -u $GITHUB_ACTOR -p $GITHUB_TOKEN ghcr.io")
+            os.system("skopeo login -u $GITHUB_ACTOR -p $GITHUB_TOKEN ghcr.io")
             tags = subprocess.run(f"skopeo list-tags docker://{image_str} | jq -r '.Tags[]'", shell=True, text=True, check=True, capture_output=True).stdout.split()
-            if tag_re[1:] == 'latest':
+            if tag_re == '#latest':
                 result_tag = get_latest_stable_version(tags)
             else:
                 result_tag = get_latest_version_by_regex(tags, tag_re[1:])
             if not result_tag:
                 print(f"::error::No matching tag found for {image_str} with pattern {tag_re}")
-                #raise ValueError(f"No matching tag found for {image_str} with pattern {tag_re}")
                 sys.exit(1)
             return(result_tag)
         except Exception as e:


### PR DESCRIPTION
# Pull Request

## Summary

charts-values-update-action can optionally publish charts to `ghcr.io` and outputs charts meta-data needed for AM generation

## Breaking Change?

- [ ] Yes
- [X] No

## Scope / Project

`actions`
