### PR TITLE
bigfix: #414 Removed persist-credentials from npm

### DIFF
--- a/.github/workflows/re-npm-publish.yml
+++ b/.github/workflows/re-npm-publish.yml
@@ -51,7 +51,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
-          persist-credentials: false
           ref: ${{ inputs.ref}}
           fetch-depth: 0
 


### PR DESCRIPTION
# Pull Request

## Summary
Removed persist-credentials from re-npm-publish

## Issue
#414 414

## Breaking Change?
- [ ] Yes
- [ ] No

If yes, describe the breaking change and its impact (e.g., API changes, behavior changes, or required updates for users).

## Scope / Project
Specify the component, module, or project area affected by this change (e.g., `docs`, `actions`, `workflows`).

## Implementation Notes
Provide details on how the change was implemented, including any technical considerations, trade-offs, or notable design decisions. Leave blank if not applicable.

## Tests / Evidence
Describe how the changes were verified, including:
- Tests added or updated (e.g., unit, integration, end-to-end)
- Manual testing steps or results
- Screenshots, logs, or other evidence (if applicable)

## Additional Notes
Include any extra information, such as:
- Dependencies introduced
- Future work or follow-up tasks
- Reviewer instructions or context
- References to related PRs or discussions

Leave blank if not applicable.
