### PR TITLE
fix: fixed severity scope on Grype CSV file generation

### DIFF
--- a/.github/workflows/re-security-scan.yml
+++ b/.github/workflows/re-security-scan.yml
@@ -142,12 +142,17 @@ jobs:
                 (.security_severity | tonumber) >= 7
               ) | del(.security_severity) | del(.info)
               )' "${SARIF_FILE%.sarif}.ext.sarif" > "${SARIF_FILE%.sarif}.filtered.sarif"
-          mv "${SARIF_FILE%.sarif}.filtered.sarif" "$SARIF_FILE"
+              mv "${SARIF_FILE%.sarif}.filtered.sarif" "$SARIF_FILE"
           fi
           # Convert to CSV for easier reading
-          jq --raw-output '["CVE", "Severity", "Provider Severity", "Type", "Package", "Affected Version", "Fix Version", "Summary"] as $headers | (
+          SECURITY_SEVERITY_THRESHOLD='0'
+          if [ "${ONLY_HIGH_CRITICAL}" = "true" ]; then
+            SECURITY_SEVERITY_THRESHOLD='7'
+          fi
+          jq --raw-output --arg sst "$SECURITY_SEVERITY_THRESHOLD" '["CVE", "Severity", "Provider Severity", "Type", "Package", "Affected Version", "Fix Version", "Summary"] as $headers | (
               $headers, (
-                  .runs[0].results[] as $result | [
+                  .runs[0].results[] as $result | if ($result.security_severity | tonumber) >= ($sst | tonumber) then
+                  [
                       ($result.info | capture("Vulnerability (?<cve>.*)"; "n") | .cve),
                       ($result.security_severity | tonumber | if . < 4 then "Low" elif . < 7 then "Medium" elif . < 9 then "High" else "Critical" end),
                       ($result.info | capture("Severity: (?<severity>\\w+)"; "n") | .severity),
@@ -157,7 +162,7 @@ jobs:
                       ($result.info | capture("Fix Version: (?<fix_version>.*)"; "n") | .fix_version),
                       $result.message.text
 
-                  ]
+                  ] else empty end
               )
           ) | @csv' "${SARIF_FILE%.sarif}.ext.sarif" > "${SARIF_FILE%.sarif}.csv"
           rm "${SARIF_FILE%.sarif}.ext.sarif"


### PR DESCRIPTION
# Pull Request

## Summary
Fixed severity scope on Grype CSV file generation
Now only High & Critical vulnerabilities go to CSV when `only-high-critical` workflow parameter set to `true`

## Issue
No Issie

## Breaking Change?
- [ ] Yes
- [X] No

## Scope / Project
`workflows`

## Implementation Notes
None

## Tests / Evidence

https://github.com/borislavr/pgskipper-patroni/actions/runs/18371502506
Check Artifacts
