### PR TITLE
feat: update re-security-scan.yml

### DIFF
--- a/.github/workflows/re-security-scan.yml
+++ b/.github/workflows/re-security-scan.yml
@@ -36,6 +36,11 @@ on:
         required: false
         default: true
         type: boolean
+      upload-sarif-to-security:
+        description: "Upload SARIF files to repository's Security"
+        type: boolean
+        required: false
+        default: true
 
 permissions:
   contents: read
@@ -226,6 +231,7 @@ jobs:
           rm "${SARIF_FILE%.sarif}.ext.sarif"
 
       - name: Upload Grype SARIF
+        if: inputs.upload-sarif-to-security
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: |
@@ -319,6 +325,7 @@ jobs:
           rm "${SARIF_FILE%.sarif}.ext.sarif"
 
       - name: Upload Trivy SARIF
+        if: inputs.upload-sarif-to-security
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: ${{ needs.init.outputs.TRIVY_FILENAME }}


### PR DESCRIPTION
# Pull Request

## Summary
Added new parameter upload-sarif-to-security (default `true`). It defines to upload security scan results to repository's `Security` -> `Code scaning` or not. 

## Issue
Link to the issue(s) this PR addresses (e.g., `Fixes #123` or `Closes #456`). If no issue exists, explain why this change is necessary.

## Breaking Change?
- [ ] Yes
- [X] No


## Scope / Project
`workflows`.
