### PR TITLE
feat: added two new parameters grype-version & trivy-version

### DIFF
--- a/.github/workflows/re-security-scan.yml
+++ b/.github/workflows/re-security-scan.yml
@@ -21,11 +21,21 @@ on:
         required: false
         default: true
         type: boolean
+      trivy-version:
+        description: "Trivy version"
+        required: false
+        default: latest
+        type: string
       grype-scan:
         description: "Grype scan"
         required: false
         default: true
         type: boolean
+      grype-version:
+        description: "Grype version"
+        required: false
+        default: latest
+        type: string
       continue-on-error:
         description: "Continue on error"
         required: false
@@ -159,9 +169,16 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
-
+      - name: Check Grype version
+        run: |
+          if [ "${{ inputs.grype-version }}" == "latest" ]; then
+            echo "GRYPE_VERSION=" >> $GITHUB_ENV
+          else
+            echo "GRYPE_VERSION=${{ inputs.grype-version }}" >> $GITHUB_ENV
+          fi
       - name: "Grype scan (Docker: High+Critical)"
         if: ${{ inputs.target == 'docker' }}
+        continue-on-error: ${{ inputs.continue-on-error }}
         id: grype-docker
         uses: anchore/scan-action@7037fa011853d5a11690026fb85feee79f4c946c #v7.3.2
         with:
@@ -171,10 +188,11 @@ jobs:
           severity-cutoff: critical
           only-fixed: ${{ inputs.only-fixed }}
           output-format: sarif
-        continue-on-error: ${{ inputs.continue-on-error }}
+          grype-version: ${{ env.GRYPE_VERSION }}
 
       - name: "Grype scan (Source: High+Critical)"
         if: ${{ inputs.target == 'source' }}
+        continue-on-error: ${{ inputs.continue-on-error }}
         id: grype-source
         uses: anchore/scan-action@7037fa011853d5a11690026fb85feee79f4c946c #v7.3.2
         with:
@@ -184,7 +202,7 @@ jobs:
           severity-cutoff: critical
           only-fixed: ${{ inputs.only-fixed }}
           output-format: sarif
-        continue-on-error: ${{ inputs.continue-on-error }}
+          grype-version: ${{ env.GRYPE_VERSION }}
 
       - name: "Convert Grype SARIF to CSV"
         env:
@@ -296,6 +314,7 @@ jobs:
 
       - name: "Trivy scan (Docker: ${{ env.TRIVY_SEVERITY }})"
         if: ${{ inputs.target == 'docker' }}
+        continue-on-error: ${{ inputs.continue-on-error }}
         id: trivy-docker
         uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518 #v0.34.1
         with:
@@ -305,11 +324,11 @@ jobs:
           format: "sarif"
           ignore-unfixed: ${{ inputs.only-fixed }}
           limit-severities-for-sarif: true
-          version: "v0.69.2"
-        continue-on-error: ${{ inputs.continue-on-error }}
+          version: ${{ inputs.trivy-version }}
 
       - name: "Trivy scan (Source: ${{ env.TRIVY_SEVERITY }})"
         if: ${{ inputs.target == 'source' }}
+        continue-on-error: ${{ inputs.continue-on-error }}
         id: trivy-source
         uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518 #v0.34.1
         with:
@@ -319,8 +338,7 @@ jobs:
           format: "sarif"
           ignore-unfixed: ${{ inputs.only-fixed }}
           limit-severities-for-sarif: true
-          version: "v0.69.2"
-        continue-on-error: ${{ inputs.continue-on-error }}
+          version: ${{ inputs.trivy-version }}
 
       - name: "Convert Trivy SARIF to CSV"
         env:


### PR DESCRIPTION
# Pull Request

## Summary
Provide a concise description of what this pull request does and why it is needed.

## Issue

#618 

## Breaking Change?
- [ ] Yes
- [X] No

## Scope / Project
`workflows`

## Implementation Notes
Added two new not mandatory parameters into re-security-scan.yml workflow. 
- grype-version (default value `latest`)
- trivy-version (default value `latest`)

## Tests / Evidence
Execution with default parameters passed to reusable workflow:
https://github.com/MyBorislavrOrg/qubership-jaeger/actions/runs/22617787218
Execution with exact versions:
https://github.com/MyBorislavrOrg/qubership-jaeger/actions/runs/22617903648
Execution without versions parameters (reusable workflow defaults play the role. Backward compatibility.):
https://github.com/MyBorislavrOrg/qubership-jaeger/actions/runs/22617671413