### PR TITLE
fix: invalidate maven cache on pom.xml changes

### DIFF
--- a/actions/maven-snapshot-deploy/action.yaml
+++ b/actions/maven-snapshot-deploy/action.yaml
@@ -189,9 +189,9 @@ runs:
       uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       with:
         path: ~/.m2/repository
-        key: maven-${{ runner.os }}
+        key: maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          maven-${{ runner.os }}
+          maven-${{ runner.os }}-
 
     - name: "Set up JDK for deployment"
       if: ${{ inputs.maven-command == 'deploy' }}


### PR DESCRIPTION
# Pull Request

## Summary
**Problem:** the current cache key depends only on the runner OS, so it is never invalidated when maven dependencies change. As a result, the same cache may be reused indefinitely even after pom.xml updates.

**Proposed solution**: include a hash of `pom.xml` files in the cache key so the cache is invalidated when the dependency configuration changes, while still allowing fallback restores via a prefix key.

**Trade-offs:** existing caches in target repositories will not match the new key, so the first build after this change will not get a cache hit and will need to download all dependencies.

## Issue
This ensures the maven cache stays aligned with the current dependency configuration. When dependencies change, a new cache is created, keeping the cache closer to the actual state and reducing the amount of dependencies that need to be downloaded during builds.

## Breaking Change?
- [ ] Yes
- [x] No

## Scope / Project
Workflows
