### PR TITLE
fix: truncate each tag individually in multi-tag templates

### DIFF
--- a/actions/metadata-action/README.md
+++ b/actions/metadata-action/README.md
@@ -171,16 +171,18 @@ Docker image tags have a maximum length of **128 characters** and must end with 
 
 This action automatically:
 
-- Truncates the generated tag to `tag-max-length` characters (default: `128`)
+- Truncates **each individual tag** to `tag-max-length` characters (default: `128`)
 - Strips trailing non-alphanumeric characters after truncation
 
-When truncation occurs, a warning is logged:
+When a template produces multiple comma-separated tags (e.g. `"{{ref-name}}-{{timestamp}}, {{ref-name}}-{{short-sha}}, {{ref-name}}, {{short-sha}}"`), each tag is evaluated and truncated **independently**. This ensures that shorter tags (such as `{{short-sha}}`) are always present in the output even when earlier tags in the list are long.
+
+When truncation occurs, a warning is logged per affected tag:
 
 ```text
 ⚠ Tag was truncated from 145 to 128 characters: "very-long-branch-..." -> "very-long-branch"
 ```
 
-**Important:** truncation always cuts from the end of the rendered string. For a template like `{{ref-name}}-{{timestamp}}-{{runNumber}}`, if `ref-name` is very long, the `timestamp` and `runNumber` parts may be cut off entirely.
+**Important:** truncation cuts from the end of each individual tag. For a single-tag template like `{{ref-name}}-{{timestamp}}-{{runNumber}}`, if `ref-name` is very long, the `timestamp` and `runNumber` parts may be cut off entirely.
 
 To avoid this, use the length modifier `{{key:N}}` to limit specific placeholders:
 
@@ -194,6 +196,16 @@ branches-template:
 | ------------- | ------------------------------- | ------------------------------------------------ |
 | No limit      | `{{ref-name}}-{{timestamp}}`    | `<first 113 chars of ref-name>` (timestamp lost) |
 | With modifier | `{{ref-name:80}}-{{timestamp}}` | `<80 chars of ref-name>-20250313235959`          |
+
+For multi-tag templates, truncation is applied per tag, so all tags are guaranteed to appear in the output (each within the length limit):
+
+```text
+Template:  "{{ref-name}}-{{timestamp}}, {{ref-name}}-{{short-sha}}, {{ref-name}}, {{short-sha}}"
+ref-name:  fix-increase-integration-tests-memory  (38 chars)
+
+Result:    "fix-increase-integration-tests-memory-20260316115900, fix-increase-integration-tests-memory-313feeac7a1, fix-increase-integration-tests-memory, 313feeac7a1"
+           ↑ each tag is within 128 chars, including the short-sha tag at the end
+```
 
 ### Semantic Version Parsing Contract
 
@@ -260,4 +272,4 @@ The configuration file for this action must adhere to [the schema defined](https
 - **Missing outputs:** Check if the action ran successfully; use `debug: true` for logs.
 - **Configuration errors:** Validate your YAML against the schema at [config.schema.json](https://github.com/netcracker/qubership-workflow-hub/blob/main/actions/metadata-action/config.schema.json).
 - **Branch/tag name issues:** Use `replace-symbol` to customize how '/' is replaced in names (default is `-`).
-- **Tag too long:** Use `tag-max-length` to limit the generated tag length. If important parts like `timestamp` get cut off, use length modifiers in the template (e.g. `{{ref-name:80}}-{{timestamp}}`). See [Tag Length Limiting](#tag-length-limiting) for details.
+- **Tag too long:** Use `tag-max-length` to limit the generated tag length. When using multi-tag templates (comma-separated), each tag is truncated independently, so all tags appear in the output. For single-tag templates where important parts like `timestamp` get cut off, use length modifiers (e.g. `{{ref-name:80}}-{{timestamp}}`). See [Tag Length Limiting](#tag-length-limiting) for details.

--- a/actions/metadata-action/dist/index.js
+++ b/actions/metadata-action/dist/index.js
@@ -32967,10 +32967,15 @@ async function run() {
     }
     action_logger_default.debugJSON("Template Values", values);
     const rendered = fillTemplate(selectedTemplateAndTag.template, values, true);
-    let result = truncateTag(rendered, tagMaxLength);
-    if (result !== rendered) {
-      action_logger_default.warn(`Tag was truncated from ${rendered.length} to ${result.length} characters: "${rendered}" -> "${result}"`);
-    }
+    const renderedTags = rendered.split(",").map((tag) => tag.trim()).filter(Boolean);
+    const truncatedTags = renderedTags.map((tag) => {
+      const truncated = truncateTag(tag, tagMaxLength);
+      if (truncated !== tag) {
+        action_logger_default.warn(`Tag was truncated from ${tag.length} to ${truncated.length} characters: "${tag}" -> "${truncated}"`);
+      }
+      return truncated;
+    });
+    let result = truncatedTags.join(", ");
     if (inputs.mergeTags && inputs.extraTags) {
       const normalizedExtraTags = normalizeExtraTags(inputs.extraTags).map((tag) => {
         const truncated = truncateTag(tag, tagMaxLength);

--- a/actions/metadata-action/src/index.js
+++ b/actions/metadata-action/src/index.js
@@ -247,10 +247,15 @@ async function run() {
     log.debugJSON("Template Values", values);
 
     const rendered = fillTemplate(selectedTemplateAndTag.template, values, true);
-    let result = truncateTag(rendered, tagMaxLength);
-    if (result !== rendered) {
-      log.warn(`Tag was truncated from ${rendered.length} to ${result.length} characters: "${rendered}" -> "${result}"`);
-    }
+    const renderedTags = rendered.split(",").map((tag) => tag.trim()).filter(Boolean);
+    const truncatedTags = renderedTags.map((tag) => {
+      const truncated = truncateTag(tag, tagMaxLength);
+      if (truncated !== tag) {
+        log.warn(`Tag was truncated from ${tag.length} to ${truncated.length} characters: "${tag}" -> "${truncated}"`);
+      }
+      return truncated;
+    });
+    let result = truncatedTags.join(", ");
 
     if (inputs.mergeTags && inputs.extraTags) {
       const normalizedExtraTags = normalizeExtraTags(inputs.extraTags).map((tag) => {

--- a/actions/metadata-action/tests/integration.index.render.test.js
+++ b/actions/metadata-action/tests/integration.index.render.test.js
@@ -198,6 +198,45 @@ describe("index.js template rendering", () => {
     );
   });
 
+  test("should truncate each tag individually when template contains multiple comma-separated tags", async () => {
+    // Simulate a long branch name that causes per-tag truncation
+    mockRefNormalizer.extract.mockReturnValue({
+      rawName: "refs/heads/fix-increase-integration-tests-memory",
+      normalizedName: "fix-increase-integration-tests-memory",
+      isTag: false,
+      isBranch: true,
+      type: "branch"
+    });
+    core.getInput.mockImplementation((name) => {
+      const map = {
+        ref: "refs/heads/fix-increase-integration-tests-memory",
+        "short-sha": "11",
+        "dry-run": "false",
+        "show-report": "false",
+        "debug": "false",
+        "extra-tags": "",
+        "merge-tags": "false",
+        "default-template": "{{ref-name}}-{{timestamp}}, {{ref-name}}-{{short-sha}}, {{ref-name}}, {{short-sha}}"
+      };
+      return map[name] ?? "";
+    });
+    mockConfigLoader.load.mockReturnValue(null);
+
+    await run();
+
+    const resultCall = core.setOutput.mock.calls.find(([key]) => key === "result");
+    const rendered = resultCall ? resultCall[1] : null;
+    const tags = rendered.split(",").map((t) => t.trim());
+
+    // Every individual tag must be within the 128-char limit
+    for (const tag of tags) {
+      expect(tag.length).toBeLessThanOrEqual(128);
+    }
+    // The short-sha tag must be present and correct (11 chars)
+    const shortShaTag = tags.find((t) => /^[0-9a-f]{11}$/.test(t));
+    expect(shortShaTag).toBeDefined();
+  });
+
   test("should skip invalid template entries", async () => {
     mockConfigLoader.load.mockReturnValue({
       "default-template": "fallback-template",


### PR DESCRIPTION
## Summary
Fix incorrect tag truncation in `metadata-action` when `default-template` produces multiple comma-separated tags. Previously, the entire rendered string was truncated as a single value, which caused trailing tags (e.g. `{{short-sha}}`) to be silently dropped. Now each tag is truncated independently.

## Issue
Fixes #654

## Breaking Change?
- [ ] Yes
- [x] No

## Scope / Project
`actions/metadata-action`

## Implementation Notes
The root cause was in `src/index.js`: after `fillTemplate()` renders the template string, the result was passed directly to `truncateTag()` as one string. For a template like:

```
"{{ref-name}}-{{timestamp}}, {{ref-name}}-{{short-sha}}, {{ref-name}}, {{short-sha}}"
```

this produced a 155-char string that got sliced to 128, cutting off the last tags entirely.

**Fix:** split the rendered string by `,`, trim each part, truncate each tag individually to `tag-max-length`, then rejoin with `", "`. Extra tags (from `extra-tags` input) were already handled per-tag and required no changes.

Documentation in `README.md` updated to reflect the new per-tag truncation behavior, including an example from the original bug report.

## Tests / Evidence
New integration test added in `tests/integration.index.render.test.js`:

> _"should truncate each tag individually when template contains multiple comma-separated tags"_

Simulates a long branch name (`fix-increase-integration-tests-memory`) with template producing 4 comma-separated tags. Asserts:
- Every individual tag is ≤ 128 characters
- The `{{short-sha}}` tag (11 chars) is present and correct in the output

All 35 tests pass:
```
Test Suites: 5 passed, 5 total
Tests:       35 passed, 35 total
```

## Additional Notes
The fix is backward-compatible - single-tag templates behave identically to before (split by `,` produces one element, truncated as usual).
