### PR TITLE
feat(actions/k8s-hardening-scan): add Kubernetes container hardening scan action

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,7 +157,8 @@ logger for GitHub Actions. Node.js actions reference it as a local file dependen
 
 ## What NOT to do
 
-- Do not use `@main` in workflow examples or documentation — always use the latest release tag (check with `git tag --list 'v*' --sort=-version:refname | head -1`)
+- Do not use `@main` in workflow examples or documentation — always use the latest release tag
+  (check with `git tag --list 'v*' --sort=-version:refname | head -1`)
 - Do not add required inputs without treating it as a breaking change
 - Do not rename or remove existing inputs/outputs without a deprecation cycle
 - Do not commit `node_modules/`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ duplicate pipeline scripts.
 ## Repository structure
 
 ```text
-actions/          — 22 individual GitHub Actions (each self-contained)
+actions/          — 23 individual GitHub Actions (each self-contained)
 packages/         — Shared internal packages used by Node.js actions
   action-logger/  — Lightweight colored logger (@qubership/action-logger)
 .github/

--- a/actions/k8s-hardening-scan/README.md
+++ b/actions/k8s-hardening-scan/README.md
@@ -1,0 +1,165 @@
+# 🚀 Kubernetes Hardening Scan
+
+Validates container hardening compliance for Kubernetes deployments by scanning running workloads
+with Kubescape (NSA, MITRE, and DevOpsBest frameworks) and optionally scanning Helm chart
+configurations with Trivy. Produces a markdown report posted to the GitHub Actions step summary
+and uploads raw JSON results as workflow artifacts.
+
+---
+
+## Features
+
+- Installs Kubescape at a pinned SHA — no floating version risk
+- Scans all specified namespaces against NSA, MITRE, and DevOpsBest security frameworks
+- Applies a configurable severity threshold (medium) and a compliance threshold of 50%
+- Generates a per-Deployment markdown table with pass/fail status for each control
+- Checks for critical exposed ports and containers using the `latest` image tag
+- Marks configurable rules as mandatory; writes `failed_mandatory_checks.json` when any fail
+- Appends the full markdown report to the GitHub Actions step summary
+- Optionally scans Helm chart misconfiguration with Trivy
+- Can gate the workflow — fails the job when mandatory checks are violated
+
+---
+
+## 📌 Inputs
+
+| Name | Description | Required | Default |
+|------|-------------|----------|---------|
+| `namespaces` | Comma-separated list of Kubernetes namespaces to include in the scan | No | - |
+| `output-file` | Base filename for JSON scan results (prefixed by tool name) | No | `results.json` |
+| `install-kubescape` | Install Kubescape before scanning. Set to `false` if already installed | No | `true` |
+| `execute-kubescape-scan` | Run the Kubescape scan step | No | `true` |
+| `execute-trivy-scan` | Run the Trivy Helm chart misconfiguration scan (requires repository checkout) | No | `false` |
+| `fail-on-mandatory-checks` | Fail the job if any mandatory hardening checks did not pass | No | `false` |
+| `config-file` | Path to the caller's hardening config YAML (overrides mandatory flags per rule) | No | `.github/hardening-config.yaml` |
+
+---
+
+## 📌 Outputs
+
+This action produces no step outputs. Results are communicated through:
+
+- GitHub Actions step summary (markdown report)
+- Uploaded artifacts (`kubescape-<output-file>`, `trivy-<output-file>`)
+- `failed_mandatory_checks.json` written to the workspace (when mandatory checks fail)
+
+---
+
+## How it works
+
+1. **Install Kubescape** — downloads and installs Kubescape from a pinned commit SHA via the
+   official install script (skipped when `install-kubescape` is `false`).
+1. **Kubescape scan** — runs `kubescape scan framework nsa,mitre,devopsbest` against the
+   specified namespaces with `--scan-images`, severity threshold `medium`, and compliance
+   threshold `50`. Output is saved as `kubescape-<output-file>`. Continues on error so
+   subsequent steps always run.
+1. **Generate markdown report** — `report-generator.py` reads the Kubescape JSON, loads the
+   hardening config, and generates a per-Deployment table showing pass/fail for each control.
+   The report is appended to `$GITHUB_STEP_SUMMARY`.
+1. **Upload Kubescape artifact** — uploads `kubescape-<output-file>` as a workflow artifact.
+1. **Checkout repository** — checks out the calling repository into `temp/repocode` (always
+   runs; required for the Trivy step).
+1. **Install Trivy** — installs Trivy via `aquasecurity/setup-trivy` (only when
+   `execute-trivy-scan` is `true`).
+1. **Trivy scan** — runs `trivy config` on the repository root to detect Helm chart
+   misconfigurations. Output is saved as `trivy-<output-file>`. Continues on error.
+1. **Upload Trivy artifact** — uploads `trivy-<output-file>` as a workflow artifact (only
+   when `execute-trivy-scan` is `true`).
+1. **Fail on mandatory checks** — if `fail-on-mandatory-checks` is `true` and
+   `failed_mandatory_checks.json` exists in the workspace, prints the failures and exits with
+   code `1`.
+
+---
+
+## Additional Information
+
+### Hardening config file
+
+The action ships a built-in `hardening-config.yaml` that defines which rules are mandatory.
+The caller can provide a custom config at `config-file` (default: `.github/hardening-config.yaml`).
+The custom config supports an `ignored_checks` list that marks specific rule IDs as non-mandatory:
+
+```yaml
+ignored_checks:
+  - C-0048
+  - Critical-Ports
+```
+
+Any rule ID listed under `ignored_checks` will have its `mandatory` flag set to `false` for the
+run, suppressing failures for that check even when `fail-on-mandatory-checks` is `true`.
+
+### Built-in mandatory rules
+
+The following rules are mandatory by default (defined in the bundled `hardening-config.yaml`):
+
+| Rule ID | Name |
+|---------|------|
+| `C-0013` | Non-root containers |
+| `C-0016` | Allow privilege escalation |
+| `C-0017` | Immutable container filesystem |
+| `C-0055` | Linux hardening |
+| `C-0041` | HostNetwork access |
+| `C-0045` | Writable hostPath mount |
+| `C-0048` | HostPath mount |
+| `Critical-Ports` | Critical ports (22, 23, 25, 53, 67–69, 110, 143, 161, 162, 389, 636, 993, 995) |
+| `No-Latest-Tag` | No `latest` image tag |
+
+### Trivy scan scope
+
+When `execute-trivy-scan` is `true`, the action checks out the repository and scans the entire
+repository root with `trivy config`. This detects misconfigurations in Helm chart templates and
+Kubernetes manifests committed to the repository. It does **not** scan running cluster workloads —
+that is the role of the Kubescape step.
+
+### Namespace targeting
+
+The `namespaces` input is passed directly to `--include-namespaces`. Supply a single namespace
+or a comma-separated list (e.g. `default,kube-system`). Omitting this input causes Kubescape to
+scan all accessible namespaces.
+
+---
+
+## Usage
+
+```yaml
+name: Kubernetes Hardening Scan
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * 1'
+
+jobs:
+  hardening-scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Run Kubernetes Hardening Scan
+        uses: netcracker/qubership-workflow-hub/actions/k8s-hardening-scan@v2.2.0
+        with:
+          namespaces: default
+          output-file: results.json
+          install-kubescape: 'true'
+          execute-kubescape-scan: 'true'
+          execute-trivy-scan: 'false'
+          fail-on-mandatory-checks: 'false'
+          config-file: .github/hardening-config.yaml
+```
+
+---
+
+## Notes
+
+- The action requires a Kubernetes cluster to be reachable from the runner (kubeconfig must be
+  configured before calling this action).
+- Kubescape is installed at a pinned commit SHA (`1d5520f7`) — update the install step if a
+  newer version is required.
+- `fail-on-mandatory-checks: 'true'` causes the job to fail only when `failed_mandatory_checks.json`
+  is present in the workspace, which is written by `report-generator.py` when at least one
+  mandatory check fails.
+- The Trivy scan checks out the repository into `temp/repocode`; ensure this path does not
+  conflict with other steps.
+- All boolean inputs (`install-kubescape`, `execute-kubescape-scan`, `execute-trivy-scan`,
+  `fail-on-mandatory-checks`) must be passed as strings (`'true'` / `'false'`), not YAML booleans.
+- Always pin to `@v2.2.0` or a specific SHA — never `@main` in production.

--- a/actions/k8s-hardening-scan/action.yaml
+++ b/actions/k8s-hardening-scan/action.yaml
@@ -54,20 +54,20 @@ runs:
 
     - name: Upload json as artifact
       if: inputs.execute-kubescape-scan == 'true'
-      uses: actions/upload-artifact@v7.0.1
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         path: kubescape-${{ inputs.output-file }}
         archive: false
 
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         path: temp/repocode
         persist-credentials: false
 
     - name: Install Trivy
       if: inputs.execute-trivy-scan == 'true'
-      uses: aquasecurity/setup-trivy@v0.2.6
+      uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.6
 
     - name: Scan Helm chart with Trivy (misconfigurations + images)
       if: inputs.execute-trivy-scan == 'true'
@@ -83,7 +83,7 @@ runs:
 
     - name: Upload json as artifact
       if: inputs.execute-trivy-scan == 'true'
-      uses: actions/upload-artifact@v7.0.1
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         path: temp/repocode/trivy-${{ inputs.output-file }}
         archive: false

--- a/actions/k8s-hardening-scan/action.yaml
+++ b/actions/k8s-hardening-scan/action.yaml
@@ -1,0 +1,101 @@
+name: Kubernetes Hardening Scan
+description: Container Hardening Validation
+inputs:
+  namespaces:
+    type: string
+  output-file:
+    type: string
+    default: "results.json"
+  install-kubescape:
+    type: string
+    default: true
+  execute-kubescape-scan:
+    type: string
+    default: true
+  execute-trivy-scan:
+    type: string
+    default: false
+  fail-on-mandatory-checks:
+    type: string
+    default: false
+  config-file:
+    type: string
+    default: ".github/hardening-config.yaml"
+runs:
+  using: "composite"
+  steps:
+    - name: Install Kubescape
+      if: inputs.install-kubescape == 'true'
+      shell: bash
+      run: |
+        curl -s https://raw.githubusercontent.com/kubescape/kubescape/1d5520f7293f418dff829bfd7ed75b1f1867ea07/install.sh | /bin/bash
+
+    - name: Scan with Kubescape (NSA + MITRE + DevOpsBest)
+      if: inputs.execute-kubescape-scan == 'true'
+      shell: bash
+      run: |
+        export PATH=$PATH:/home/runner/.kubescape/bin
+        kubescape scan framework nsa,mitre,devopsbest \
+          --include-namespaces ${{ inputs.namespaces }} \
+          --scan-images \
+          --verbose \
+          --format json \
+          --output kubescape-${{ inputs.output-file }} \
+          --severity-threshold medium \
+          --compliance-threshold 50   # (0-100)
+      continue-on-error: true
+
+    - name: Generate markdown report
+      if: inputs.execute-kubescape-scan == 'true'
+      shell: bash
+      run: |
+        python3 ${GITHUB_ACTION_PATH}/report-generator.py -i kubescape-${{ inputs.output-file }} -o kubescape-report.md -c ${{ inputs.config-file }}
+        cat kubescape-report.md >> $GITHUB_STEP_SUMMARY
+
+    - name: Upload json as artifact
+      if: inputs.execute-kubescape-scan == 'true'
+      uses: actions/upload-artifact@v7.0.1
+      with:
+        path: kubescape-${{ inputs.output-file }}
+        archive: false
+
+    - name: Checkout code
+      uses: actions/checkout@v6
+      with:
+        path: temp/repocode
+        persist-credentials: false
+
+    - name: Install Trivy
+      if: inputs.execute-trivy-scan == 'true'
+      uses: aquasecurity/setup-trivy@v0.2.6
+
+    - name: Scan Helm chart with Trivy (misconfigurations + images)
+      if: inputs.execute-trivy-scan == 'true'
+      shell: bash
+      working-directory: temp/repocode
+      run: |
+        trivy config \
+          --exit-code 1 \
+          --format json \
+          --output trivy-${{ inputs.output-file }} \
+          .
+      continue-on-error: true
+
+    - name: Upload json as artifact
+      if: inputs.execute-trivy-scan == 'true'
+      uses: actions/upload-artifact@v7.0.1
+      with:
+        path: temp/repocode/trivy-${{ inputs.output-file }}
+        archive: false
+
+    - name: Fail on mandatory checks failure
+      if: inputs.fail-on-mandatory-checks == 'true'
+      shell: bash
+      run: |
+        if [ -f failed_mandatory_checks.json ]; then
+          echo "Mandatory checks failed. Failing the workflow."
+          cat failed_mandatory_checks.json
+          exit 1
+        else
+          echo "All mandatory checks passed."
+        fi

--- a/actions/k8s-hardening-scan/hardening-config.yaml
+++ b/actions/k8s-hardening-scan/hardening-config.yaml
@@ -1,0 +1,53 @@
+hardening_rules:
+  C-0013:
+    name: "Non-root containers"
+    description: "Ensure that containers are not running as root."
+    mandatory: true
+  C-0016:
+    name: "Allow privilege escalation"
+    description: "Ensure that containers are not allowed to escalate privileges."
+    mandatory: true
+  C-0017:
+    name: "Immutable container filesystem"
+    description: "Ensure that containers have an immutable filesystem."
+    mandatory: true
+  C-0055:
+    name: "Linux hardening"
+    description: "Ensure that containers follow Linux hardening best practices."
+    mandatory: true
+  C-0041:
+    name: "HostNetwork access"
+    description: "Ensure that containers are not using the host network."
+    mandatory: true
+  C-0045:
+    name: "Writable hostPath mount"
+    description: "Ensure that containers are not mounting writable hostPath volumes."
+    mandatory: true
+  C-0048:
+    name: "HostPath mount"
+    description: "Ensure that containers are not mounting hostPath volumes."
+    mandatory: true
+  Critical-Ports:
+    name: "Critical Ports"
+    description: "Ensure that no containers are exposing critical ports."
+    mandatory: true
+    critical_ports:
+      - 22
+      - 23
+      - 25
+      - 53
+      - 67
+      - 68
+      - 69
+      - 110
+      - 143
+      - 161
+      - 162
+      - 389
+      - 636
+      - 993
+      - 995
+  No-Latest-Tag:
+    name: "No 'latest' tag"
+    description: "Ensure that no containers are using the 'latest' image tag."
+    mandatory: true

--- a/actions/k8s-hardening-scan/report-generator.py
+++ b/actions/k8s-hardening-scan/report-generator.py
@@ -11,22 +11,19 @@ import os
 import sys
 from pathlib import Path
 
-
 def load_json_data(source):
     """Loads JSON from a file or URL."""
-    if source.startswith(("http://", "https://")):
+    if source.startswith(('http://', 'https://')):
         with urllib.request.urlopen(source) as response:
-            return json.loads(response.read().decode("utf-8"))
+            return json.loads(response.read().decode('utf-8'))
     else:
-        with open(source, "r", encoding="utf-8") as f:
+        with open(source, 'r', encoding='utf-8') as f:
             return json.load(f)
-
 
 def load_yaml_config(config_path):
     """Loads YAML configuration from a file."""
     import yaml
-
-    default_config_path = os.getenv("GITHUB_ACTION_PATH") + "/hardening-config.yaml"
+    default_config_path = os.getenv('GITHUB_ACTION_PATH') + '/hardening-config.yaml'
     default_config_data = {}
     config_data = {}
     # Try to load user config file
@@ -35,74 +32,68 @@ def load_yaml_config(config_path):
     #   - ControlID1
     #   - ControlID2
     if not Path(config_path).is_file():
-        print(
-            f"⚠️  Warning: Config file '{config_path}' not found. Using default config path '{default_config_path}'."
-        )
+        print(f"⚠️  Warning: Config file '{config_path}' not found. Using default config path '{default_config_path}'.")
     else:
-        with open(config_path, "r", encoding="utf-8") as f:
+        with open(config_path, 'r', encoding='utf-8') as f:
             config_data = yaml.safe_load(f)
-    with open(default_config_path, "r", encoding="utf-8") as f:
+    with open(default_config_path, 'r', encoding='utf-8') as f:
         default_config_data = yaml.safe_load(f)
     # Merge default config with user config. Setting `mandatory` field to False for checks listed in `ignored_checks` in user config.
-    for check in config_data.get("ignored_checks", []):
-        if check in default_config_data.get("hardening_rules", {}):
-            default_config_data["hardening_rules"][check]["mandatory"] = False
+    for check in config_data.get('ignored_checks', []):
+        if check in default_config_data.get('hardening_rules', {}):
+            default_config_data['hardening_rules'][check]['mandatory'] = False
     print(f"[DEBUG]: {default_config_data}")
     return default_config_data
-
 
 def get_resource_ports(resource):
     """Extracts ports from a resource definition."""
     ports = []
-    object = resource.get("object", {})
-    spec = object.get("spec", {})
-    template = spec.get("template", {})
-    spec_template = template.get("spec", {})
-    containers = spec_template.get("containers", [])
+    object = resource.get('object', {})
+    spec = object.get('spec', {})
+    template = spec.get('template', {})
+    spec_template = template.get('spec', {})
+    containers = spec_template.get('containers', [])
 
     for container in containers:
-        container_ports = container.get("ports", [])
+        container_ports = container.get('ports', [])
         for port in container_ports:
-            ports.append(port.get("containerPort"))
+            ports.append(port.get('containerPort'))
     print(f"[DEBUG] Resource: {resource.get('resourceID', 'Unknown')}, Ports: {ports}")
     return ports
-
 
 def get_resource_images(resource):
     """Extracts container images from a resource definition."""
     images = []
-    object = resource.get("object", {})
-    spec = object.get("spec", {})
-    template = spec.get("template", {})
-    spec_template = template.get("spec", {})
-    containers = spec_template.get("containers", [])
+    object = resource.get('object', {})
+    spec = object.get('spec', {})
+    template = spec.get('template', {})
+    spec_template = template.get('spec', {})
+    containers = spec_template.get('containers', [])
 
     for container in containers:
-        image = container.get("image", "")
+        image = container.get('image', '')
         if image:
             images.append(image)
     print(f"[DEBUG] Resource: {resource.get('resourceID', 'Unknown')}, Images: {images}")
     return images
 
-
 def get_status_emoji(status):
     """Returns the emoji for a given status."""
-    return "✅" if status == "passed" else "❌"
-
+    return '✅' if status == 'passed' else '❌'
 
 def generate_markdown_tables(data, config):
     """Generates markdown tables for each resourceID."""
     print(f"[DEBUG] Generating markdown tables with config: {config}")
-    results = data.get("results", [])
+    results = data.get('results', [])
     print(f"[DEBUG] Total results found: {len(results)}")
-    resources = data.get("resources", [])
+    resources = data.get('resources', [])
     print(f"[DEBUG] Total resources found: {len(resources)}")
 
     # get mandatory checks list from config file
     mandatory_checks = [
         rule_id
-        for rule_id, rule_data in config.get("hardening_rules", {}).items()
-        if rule_data.get("mandatory") is True
+        for rule_id, rule_data in config.get('hardening_rules', {}).items()
+        if rule_data.get('mandatory') is True
     ]
     print(f"[DEBUG] Mandatory checks from config: {mandatory_checks}")
     if not results:
@@ -110,13 +101,13 @@ def generate_markdown_tables(data, config):
     failed_mandatory_checks_all = {}
     output_lines = []
     for resource in results:
-        resource_id = resource.get("resourceID", "Unknown")
-        if "/Deployment/" not in resource_id:  # Skip non-deployment resources
+        resource_id = resource.get('resourceID', 'Unknown')
+        if not '/Deployment/' in resource_id:  # Skip non-deployment resources
             continue
-        resource_data = next((r for r in resources if r.get("resourceID") == resource_id), {})
+        resource_data = next((r for r in resources if r.get('resourceID') == resource_id), {})
         resource_ports = get_resource_ports(resource_data)
         resource_images = get_resource_images(resource_data)
-        controls = resource.get("controls", [])
+        controls = resource.get('controls', [])
         failed_mandatory_checks = []
 
         # Resource header
@@ -126,84 +117,65 @@ def generate_markdown_tables(data, config):
 
         # Processing each control
         for control in controls:
-            control_id = control.get("controlID", "")
-            control_name = control.get("name", "")
-            rules = control.get("rules", [])
+            control_id = control.get('controlID', '')
+            control_name = control.get('name', '')
+            rules = control.get('rules', [])
 
             # Each rule in a separate line.
             if len(rules) > 1:
                 for rule in rules:
-                    status = rule.get("status", "")
+                    status = rule.get('status', '')
                     status_emoji = get_status_emoji(status)
-                    output_lines.append(
-                        f"| {control_id} | {control_name} ({rule.get('name', '')}) | {status_emoji} |"
-                    )
-                    if (
-                        control_id in mandatory_checks
-                        and status != "passed"
-                        and control_id not in failed_mandatory_checks
-                    ):
+                    output_lines.append(f"| {control_id} | {control_name} ({rule.get('name', '')}) | {status_emoji} |")
+                    if control_id in mandatory_checks and status != 'passed' and control_id not in failed_mandatory_checks:
                         failed_mandatory_checks.append(control_id)
             else:
                 # Normal case - single rule
-                status = rules[0].get("status", "") if rules else control.get("status", {}).get("status", "")
+                status = rules[0].get('status', '') if rules else control.get('status', {}).get('status', '')
                 status_emoji = get_status_emoji(status)
                 output_lines.append(f"| {control_id} | {control_name} | {status_emoji} |")
-                if control_id in mandatory_checks and status != "passed":
+                if control_id in mandatory_checks and status != 'passed':
                     failed_mandatory_checks.append(control_id)
 
         # compare resource ports with prohibited ports list from config file and add a line to the table if there is a match.
         ports_check_success = 0
-        ports_intersection = list(
-            set(config.get("hardening_rules", {}).get("Critical-Ports", {}).get("critical_ports", []))
-            & set(resource_ports)
-        )
+        ports_intersection = list(set(config.get('hardening_rules', {}).get('Critical-Ports', {}).get('critical_ports', [])) & set(resource_ports))
         if ports_intersection:
-            output_lines.append(
-                f"| Critical-Ports | Critical Ports: {', '.join(map(str, sorted(ports_intersection)))} | ❌ |"
-            )
-            if "Critical-Ports" in mandatory_checks:
-                failed_mandatory_checks.append("Critical-Ports")
+            output_lines.append(f"| Critical-Ports | Critical Ports: {', '.join(map(str, sorted(ports_intersection)))} | ❌ |")
+            if 'Critical-Ports' in mandatory_checks:
+                failed_mandatory_checks.append('Critical-Ports')
         else:
             output_lines.append("| Critical-Ports | Critical Ports | ✅ |")
             ports_check_success += 1
         # check if any of the container images used in the resource are using the 'latest' tag and add a line to the table if there is a match.
         latest_images_check_success = 0
-        latest_images = [img for img in resource_images if img.endswith(":latest")]
+        latest_images = [img for img in resource_images if img.endswith(':latest')]
         if latest_images:
-            output_lines.append(
-                f"| Latest-Tag | Images using 'latest' tag: {', '.join(latest_images)} | ❌ |"
-            )
-            if "No-Latest-Tag" in mandatory_checks:
-                failed_mandatory_checks.append("No-Latest-Tag")
+            output_lines.append(f"| Latest-Tag | Images using 'latest' tag: {', '.join(latest_images)} | ❌ |")
+            if 'No-Latest-Tag' in mandatory_checks:
+                failed_mandatory_checks.append('No-Latest-Tag')
         else:
             output_lines.append("| Latest-Tag | No images using 'latest' tag | ✅ |")
             latest_images_check_success += 1
 
         # Add statistics for the resource
         total_controls = len(controls) + 2  # +2 for Critical-Ports and Latest-Tag checks
-        passed = (
-            sum(1 for c in controls if c.get("rules", [{}])[0].get("status", "") == "passed")
-            + ports_check_success
-            + latest_images_check_success
-        )
+        passed = sum(1 for c in controls
+                    if c.get('rules', [{}])[0].get('status', '') == 'passed') + ports_check_success + latest_images_check_success
         failed = total_controls - passed
 
         output_lines.append(f"\n**Total:** ✅ passed: {passed}, ❌ failed: {failed}\n")
-        output_lines.append(
-            f"**Failed mandatory checks:** {', '.join(failed_mandatory_checks) if failed_mandatory_checks else 'None'}\n"
-        )
+        output_lines.append(f"**Failed mandatory checks:** {', '.join(failed_mandatory_checks) if failed_mandatory_checks else 'None'}\n")
         output_lines.append("---")
 
         failed_mandatory_checks_all[resource_id] = failed_mandatory_checks
 
-    return "\n".join(output_lines), failed_mandatory_checks_all
-
+    return '\n'.join(output_lines), failed_mandatory_checks_all
 
 def generate_full_report(data, config, title="Kubescape Hardening Scan Report"):
     """Generates a full markdown report."""
     print(f"[DEBUG] Generating full report with title: {title}")
-    timestamp = __import__("datetime").datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    timestamp = __import__('datetime').datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
     report = f"""# {title}
 
@@ -213,14 +185,15 @@ def generate_full_report(data, config, title="Kubescape Hardening Scan Report"):
 
 """
 
-    results = data.get("results", [])
+    results = data.get('results', [])
     for resource in results:
-        resource_id = resource.get("resourceID", "Unknown")
-        if "/Deployment/" not in resource_id:  # Skip non-deployment resources
+        resource_id = resource.get('resourceID', 'Unknown')
+        if not '/Deployment/' in resource_id:  # Skip non-deployment resources
             continue
 
-        controls = resource.get("controls", [])
-        passed = sum(1 for c in controls if c.get("rules", [{}])[0].get("status", "") == "passed")
+        controls = resource.get('controls', [])
+        passed = sum(1 for c in controls
+                    if c.get('rules', [{}])[0].get('status', '') == 'passed')
         failed = len(controls) - passed
         report += f"- `{resource_id}`: ✅ {passed} / ❌ {failed}\n"
 
@@ -230,27 +203,28 @@ def generate_full_report(data, config, title="Kubescape Hardening Scan Report"):
 
     return report, failed_mandatory_checks_all
 
-
 def main():
-    parser = argparse.ArgumentParser(description="Converts kubescape JSON results into Markdown tables.")
-    parser.add_argument("--input", "-i", help="Path to the JSON file or URL (default: specified URL)")
-    parser.add_argument(
-        "--output",
-        "-o",
-        default="kubescape-report.md",
-        help="Path for saving the markdown file (default: kubescape-report.md)",
+    parser = argparse.ArgumentParser(
+        description='Converts kubescape JSON results into Markdown tables.'
     )
     parser.add_argument(
-        "--title",
-        "-t",
-        default="Kubescape Hardening Scan Report",
-        help="Report title",
+        '--input', '-i',
+        help='Path to the JSON file or URL (default: specified URL)'
     )
     parser.add_argument(
-        "--config",
-        "-c",
-        default=".github/hardening-config.yaml",
-        help="Path to the YAML configuration file (default: .github/hardening-config.yaml)",
+        '--output', '-o',
+        default='kubescape-report.md',
+        help='Path for saving the markdown file (default: kubescape-report.md)'
+    )
+    parser.add_argument(
+        '--title', '-t',
+        default='Kubescape Hardening Scan Report',
+        help='Report title'
+    )
+    parser.add_argument(
+        '--config', '-c',
+        default='.github/hardening-config.yaml',
+        help='Path to the YAML configuration file (default: .github/hardening-config.yaml)'
     )
 
     args = parser.parse_args()
@@ -263,19 +237,20 @@ def main():
         print("Generating markdown report...")
         report, failed_mandatory_checks_all = generate_full_report(data, config, args.title)
 
-        with open(args.output, "w", encoding="utf-8") as f:
+        with open(args.output, 'w', encoding='utf-8') as f:
             f.write(report)
 
         print(f"✅ Report successfully saved to: {args.output}")
 
         # Display brief statistics
-        results = data.get("results", [])
-        print("\n📊 Statistics:")
+        results = data.get('results', [])
+        print(f"\n📊 Statistics:")
         print(f"   Total resources: {len(results)}")
         for resource in results:
-            resource_id = resource.get("resourceID", "Unknown")
-            controls = resource.get("controls", [])
-            passed = sum(1 for c in controls if c.get("rules", [{}])[0].get("status", "") == "passed")
+            resource_id = resource.get('resourceID', 'Unknown')
+            controls = resource.get('controls', [])
+            passed = sum(1 for c in controls
+                        if c.get('rules', [{}])[0].get('status', '') == 'passed')
             print(f"   - {resource_id}: {passed}/{len(controls)} passed")
         if failed_mandatory_checks_all:
             print("\n⚠️  Failed mandatory checks:")
@@ -287,12 +262,11 @@ def main():
             print(f"\nTotal failed mandatory checks: {total_failed_mandatory_checks}")
             # If there are failed mandatory checks, save them to a JSON file for further processing in the workflow
             if total_failed_mandatory_checks > 0:
-                with open("failed_mandatory_checks.json", "w", encoding="utf-8") as f:
+                with open('failed_mandatory_checks.json', 'w', encoding='utf-8') as f:
                     json.dump(failed_mandatory_checks_all, f, indent=2)
     except Exception as e:
         print(f"❌ Error: {e}", file=sys.stderr)
         sys.exit(1)
-
 
 if __name__ == "__main__":
     main()

--- a/actions/k8s-hardening-scan/report-generator.py
+++ b/actions/k8s-hardening-scan/report-generator.py
@@ -11,19 +11,22 @@ import os
 import sys
 from pathlib import Path
 
+
 def load_json_data(source):
     """Loads JSON from a file or URL."""
-    if source.startswith(('http://', 'https://')):
+    if source.startswith(("http://", "https://")):
         with urllib.request.urlopen(source) as response:
-            return json.loads(response.read().decode('utf-8'))
+            return json.loads(response.read().decode("utf-8"))
     else:
-        with open(source, 'r', encoding='utf-8') as f:
+        with open(source, "r", encoding="utf-8") as f:
             return json.load(f)
+
 
 def load_yaml_config(config_path):
     """Loads YAML configuration from a file."""
     import yaml
-    default_config_path = os.getenv('GITHUB_ACTION_PATH') + '/hardening-config.yaml'
+
+    default_config_path = os.getenv("GITHUB_ACTION_PATH") + "/hardening-config.yaml"
     default_config_data = {}
     config_data = {}
     # Try to load user config file
@@ -32,68 +35,74 @@ def load_yaml_config(config_path):
     #   - ControlID1
     #   - ControlID2
     if not Path(config_path).is_file():
-        print(f"⚠️  Warning: Config file '{config_path}' not found. Using default config path '{default_config_path}'.")
+        print(
+            f"⚠️  Warning: Config file '{config_path}' not found. Using default config path '{default_config_path}'."
+        )
     else:
-        with open(config_path, 'r', encoding='utf-8') as f:
+        with open(config_path, "r", encoding="utf-8") as f:
             config_data = yaml.safe_load(f)
-    with open(default_config_path, 'r', encoding='utf-8') as f:
+    with open(default_config_path, "r", encoding="utf-8") as f:
         default_config_data = yaml.safe_load(f)
     # Merge default config with user config. Setting `mandatory` field to False for checks listed in `ignored_checks` in user config.
-    for check in config_data.get('ignored_checks', []):
-        if check in default_config_data.get('hardening_rules', {}):
-            default_config_data['hardening_rules'][check]['mandatory'] = False
+    for check in config_data.get("ignored_checks", []):
+        if check in default_config_data.get("hardening_rules", {}):
+            default_config_data["hardening_rules"][check]["mandatory"] = False
     print(f"[DEBUG]: {default_config_data}")
     return default_config_data
+
 
 def get_resource_ports(resource):
     """Extracts ports from a resource definition."""
     ports = []
-    object = resource.get('object', {})
-    spec = object.get('spec', {})
-    template = spec.get('template', {})
-    spec_template = template.get('spec', {})
-    containers = spec_template.get('containers', [])
+    object = resource.get("object", {})
+    spec = object.get("spec", {})
+    template = spec.get("template", {})
+    spec_template = template.get("spec", {})
+    containers = spec_template.get("containers", [])
 
     for container in containers:
-        container_ports = container.get('ports', [])
+        container_ports = container.get("ports", [])
         for port in container_ports:
-            ports.append(port.get('containerPort'))
+            ports.append(port.get("containerPort"))
     print(f"[DEBUG] Resource: {resource.get('resourceID', 'Unknown')}, Ports: {ports}")
     return ports
+
 
 def get_resource_images(resource):
     """Extracts container images from a resource definition."""
     images = []
-    object = resource.get('object', {})
-    spec = object.get('spec', {})
-    template = spec.get('template', {})
-    spec_template = template.get('spec', {})
-    containers = spec_template.get('containers', [])
+    object = resource.get("object", {})
+    spec = object.get("spec", {})
+    template = spec.get("template", {})
+    spec_template = template.get("spec", {})
+    containers = spec_template.get("containers", [])
 
     for container in containers:
-        image = container.get('image', '')
+        image = container.get("image", "")
         if image:
             images.append(image)
     print(f"[DEBUG] Resource: {resource.get('resourceID', 'Unknown')}, Images: {images}")
     return images
 
+
 def get_status_emoji(status):
     """Returns the emoji for a given status."""
-    return '✅' if status == 'passed' else '❌'
+    return "✅" if status == "passed" else "❌"
+
 
 def generate_markdown_tables(data, config):
     """Generates markdown tables for each resourceID."""
     print(f"[DEBUG] Generating markdown tables with config: {config}")
-    results = data.get('results', [])
+    results = data.get("results", [])
     print(f"[DEBUG] Total results found: {len(results)}")
-    resources = data.get('resources', [])
+    resources = data.get("resources", [])
     print(f"[DEBUG] Total resources found: {len(resources)}")
 
     # get mandatory checks list from config file
     mandatory_checks = [
         rule_id
-        for rule_id, rule_data in config.get('hardening_rules', {}).items()
-        if rule_data.get('mandatory') is True
+        for rule_id, rule_data in config.get("hardening_rules", {}).items()
+        if rule_data.get("mandatory") is True
     ]
     print(f"[DEBUG] Mandatory checks from config: {mandatory_checks}")
     if not results:
@@ -101,13 +110,13 @@ def generate_markdown_tables(data, config):
     failed_mandatory_checks_all = {}
     output_lines = []
     for resource in results:
-        resource_id = resource.get('resourceID', 'Unknown')
-        if not '/Deployment/' in resource_id:  # Skip non-deployment resources
+        resource_id = resource.get("resourceID", "Unknown")
+        if "/Deployment/" not in resource_id:  # Skip non-deployment resources
             continue
-        resource_data = next((r for r in resources if r.get('resourceID') == resource_id), {})
+        resource_data = next((r for r in resources if r.get("resourceID") == resource_id), {})
         resource_ports = get_resource_ports(resource_data)
         resource_images = get_resource_images(resource_data)
-        controls = resource.get('controls', [])
+        controls = resource.get("controls", [])
         failed_mandatory_checks = []
 
         # Resource header
@@ -117,65 +126,84 @@ def generate_markdown_tables(data, config):
 
         # Processing each control
         for control in controls:
-            control_id = control.get('controlID', '')
-            control_name = control.get('name', '')
-            rules = control.get('rules', [])
+            control_id = control.get("controlID", "")
+            control_name = control.get("name", "")
+            rules = control.get("rules", [])
 
             # Each rule in a separate line.
             if len(rules) > 1:
                 for rule in rules:
-                    status = rule.get('status', '')
+                    status = rule.get("status", "")
                     status_emoji = get_status_emoji(status)
-                    output_lines.append(f"| {control_id} | {control_name} ({rule.get('name', '')}) | {status_emoji} |")
-                    if control_id in mandatory_checks and status != 'passed' and control_id not in failed_mandatory_checks:
+                    output_lines.append(
+                        f"| {control_id} | {control_name} ({rule.get('name', '')}) | {status_emoji} |"
+                    )
+                    if (
+                        control_id in mandatory_checks
+                        and status != "passed"
+                        and control_id not in failed_mandatory_checks
+                    ):
                         failed_mandatory_checks.append(control_id)
             else:
                 # Normal case - single rule
-                status = rules[0].get('status', '') if rules else control.get('status', {}).get('status', '')
+                status = rules[0].get("status", "") if rules else control.get("status", {}).get("status", "")
                 status_emoji = get_status_emoji(status)
                 output_lines.append(f"| {control_id} | {control_name} | {status_emoji} |")
-                if control_id in mandatory_checks and status != 'passed':
+                if control_id in mandatory_checks and status != "passed":
                     failed_mandatory_checks.append(control_id)
 
         # compare resource ports with prohibited ports list from config file and add a line to the table if there is a match.
         ports_check_success = 0
-        ports_intersection = list(set(config.get('hardening_rules', {}).get('Critical-Ports', {}).get('critical_ports', [])) & set(resource_ports))
+        ports_intersection = list(
+            set(config.get("hardening_rules", {}).get("Critical-Ports", {}).get("critical_ports", []))
+            & set(resource_ports)
+        )
         if ports_intersection:
-            output_lines.append(f"| Critical-Ports | Critical Ports: {', '.join(map(str, sorted(ports_intersection)))} | ❌ |")
-            if 'Critical-Ports' in mandatory_checks:
-                failed_mandatory_checks.append('Critical-Ports')
+            output_lines.append(
+                f"| Critical-Ports | Critical Ports: {', '.join(map(str, sorted(ports_intersection)))} | ❌ |"
+            )
+            if "Critical-Ports" in mandatory_checks:
+                failed_mandatory_checks.append("Critical-Ports")
         else:
             output_lines.append("| Critical-Ports | Critical Ports | ✅ |")
             ports_check_success += 1
         # check if any of the container images used in the resource are using the 'latest' tag and add a line to the table if there is a match.
         latest_images_check_success = 0
-        latest_images = [img for img in resource_images if img.endswith(':latest')]
+        latest_images = [img for img in resource_images if img.endswith(":latest")]
         if latest_images:
-            output_lines.append(f"| Latest-Tag | Images using 'latest' tag: {', '.join(latest_images)} | ❌ |")
-            if 'No-Latest-Tag' in mandatory_checks:
-                failed_mandatory_checks.append('No-Latest-Tag')
+            output_lines.append(
+                f"| Latest-Tag | Images using 'latest' tag: {', '.join(latest_images)} | ❌ |"
+            )
+            if "No-Latest-Tag" in mandatory_checks:
+                failed_mandatory_checks.append("No-Latest-Tag")
         else:
             output_lines.append("| Latest-Tag | No images using 'latest' tag | ✅ |")
             latest_images_check_success += 1
 
         # Add statistics for the resource
         total_controls = len(controls) + 2  # +2 for Critical-Ports and Latest-Tag checks
-        passed = sum(1 for c in controls
-                    if c.get('rules', [{}])[0].get('status', '') == 'passed') + ports_check_success + latest_images_check_success
+        passed = (
+            sum(1 for c in controls if c.get("rules", [{}])[0].get("status", "") == "passed")
+            + ports_check_success
+            + latest_images_check_success
+        )
         failed = total_controls - passed
 
         output_lines.append(f"\n**Total:** ✅ passed: {passed}, ❌ failed: {failed}\n")
-        output_lines.append(f"**Failed mandatory checks:** {', '.join(failed_mandatory_checks) if failed_mandatory_checks else 'None'}\n")
+        output_lines.append(
+            f"**Failed mandatory checks:** {', '.join(failed_mandatory_checks) if failed_mandatory_checks else 'None'}\n"
+        )
         output_lines.append("---")
 
         failed_mandatory_checks_all[resource_id] = failed_mandatory_checks
 
-    return '\n'.join(output_lines), failed_mandatory_checks_all
+    return "\n".join(output_lines), failed_mandatory_checks_all
+
 
 def generate_full_report(data, config, title="Kubescape Hardening Scan Report"):
     """Generates a full markdown report."""
     print(f"[DEBUG] Generating full report with title: {title}")
-    timestamp = __import__('datetime').datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    timestamp = __import__("datetime").datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
     report = f"""# {title}
 
@@ -185,15 +213,14 @@ def generate_full_report(data, config, title="Kubescape Hardening Scan Report"):
 
 """
 
-    results = data.get('results', [])
+    results = data.get("results", [])
     for resource in results:
-        resource_id = resource.get('resourceID', 'Unknown')
-        if not '/Deployment/' in resource_id:  # Skip non-deployment resources
+        resource_id = resource.get("resourceID", "Unknown")
+        if "/Deployment/" not in resource_id:  # Skip non-deployment resources
             continue
 
-        controls = resource.get('controls', [])
-        passed = sum(1 for c in controls
-                    if c.get('rules', [{}])[0].get('status', '') == 'passed')
+        controls = resource.get("controls", [])
+        passed = sum(1 for c in controls if c.get("rules", [{}])[0].get("status", "") == "passed")
         failed = len(controls) - passed
         report += f"- `{resource_id}`: ✅ {passed} / ❌ {failed}\n"
 
@@ -203,28 +230,27 @@ def generate_full_report(data, config, title="Kubescape Hardening Scan Report"):
 
     return report, failed_mandatory_checks_all
 
+
 def main():
-    parser = argparse.ArgumentParser(
-        description='Converts kubescape JSON results into Markdown tables.'
+    parser = argparse.ArgumentParser(description="Converts kubescape JSON results into Markdown tables.")
+    parser.add_argument("--input", "-i", help="Path to the JSON file or URL (default: specified URL)")
+    parser.add_argument(
+        "--output",
+        "-o",
+        default="kubescape-report.md",
+        help="Path for saving the markdown file (default: kubescape-report.md)",
     )
     parser.add_argument(
-        '--input', '-i',
-        help='Path to the JSON file or URL (default: specified URL)'
+        "--title",
+        "-t",
+        default="Kubescape Hardening Scan Report",
+        help="Report title",
     )
     parser.add_argument(
-        '--output', '-o',
-        default='kubescape-report.md',
-        help='Path for saving the markdown file (default: kubescape-report.md)'
-    )
-    parser.add_argument(
-        '--title', '-t',
-        default='Kubescape Hardening Scan Report',
-        help='Report title'
-    )
-    parser.add_argument(
-        '--config', '-c',
-        default='.github/hardening-config.yaml',
-        help='Path to the YAML configuration file (default: .github/hardening-config.yaml)'
+        "--config",
+        "-c",
+        default=".github/hardening-config.yaml",
+        help="Path to the YAML configuration file (default: .github/hardening-config.yaml)",
     )
 
     args = parser.parse_args()
@@ -237,20 +263,19 @@ def main():
         print("Generating markdown report...")
         report, failed_mandatory_checks_all = generate_full_report(data, config, args.title)
 
-        with open(args.output, 'w', encoding='utf-8') as f:
+        with open(args.output, "w", encoding="utf-8") as f:
             f.write(report)
 
         print(f"✅ Report successfully saved to: {args.output}")
 
         # Display brief statistics
-        results = data.get('results', [])
-        print(f"\n📊 Statistics:")
+        results = data.get("results", [])
+        print("\n📊 Statistics:")
         print(f"   Total resources: {len(results)}")
         for resource in results:
-            resource_id = resource.get('resourceID', 'Unknown')
-            controls = resource.get('controls', [])
-            passed = sum(1 for c in controls
-                        if c.get('rules', [{}])[0].get('status', '') == 'passed')
+            resource_id = resource.get("resourceID", "Unknown")
+            controls = resource.get("controls", [])
+            passed = sum(1 for c in controls if c.get("rules", [{}])[0].get("status", "") == "passed")
             print(f"   - {resource_id}: {passed}/{len(controls)} passed")
         if failed_mandatory_checks_all:
             print("\n⚠️  Failed mandatory checks:")
@@ -262,11 +287,12 @@ def main():
             print(f"\nTotal failed mandatory checks: {total_failed_mandatory_checks}")
             # If there are failed mandatory checks, save them to a JSON file for further processing in the workflow
             if total_failed_mandatory_checks > 0:
-                with open('failed_mandatory_checks.json', 'w', encoding='utf-8') as f:
+                with open("failed_mandatory_checks.json", "w", encoding="utf-8") as f:
                     json.dump(failed_mandatory_checks_all, f, indent=2)
     except Exception as e:
         print(f"❌ Error: {e}", file=sys.stderr)
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/actions/k8s-hardening-scan/report-generator.py
+++ b/actions/k8s-hardening-scan/report-generator.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""
+A script for converting kubescape JSON results into Markdown tables.
+Usage: python3 generate_report.py [--input file.json] [--output report.md]
+"""
+
+import json
+import urllib.request
+import argparse
+import os
+import sys
+from pathlib import Path
+
+def load_json_data(source):
+    """Loads JSON from a file or URL."""
+    if source.startswith(('http://', 'https://')):
+        with urllib.request.urlopen(source) as response:
+            return json.loads(response.read().decode('utf-8'))
+    else:
+        with open(source, 'r', encoding='utf-8') as f:
+            return json.load(f)
+
+def load_yaml_config(config_path):
+    """Loads YAML configuration from a file."""
+    import yaml
+    default_config_path = os.getenv('GITHUB_ACTION_PATH') + '/hardening-config.yaml'
+    default_config_data = {}
+    config_data = {}
+    # Try to load user config file
+    # user config structure:
+    # ignored_checks:
+    #   - ControlID1
+    #   - ControlID2
+    if not Path(config_path).is_file():
+        print(f"⚠️  Warning: Config file '{config_path}' not found. Using default config path '{default_config_path}'.")
+    else:
+        with open(config_path, 'r', encoding='utf-8') as f:
+            config_data = yaml.safe_load(f)
+    with open(default_config_path, 'r', encoding='utf-8') as f:
+        default_config_data = yaml.safe_load(f)
+    # Merge default config with user config. Setting `mandatory` field to False for checks listed in `ignored_checks` in user config.
+    for check in config_data.get('ignored_checks', []):
+        if check in default_config_data.get('hardening_rules', {}):
+            default_config_data['hardening_rules'][check]['mandatory'] = False
+    print(f"[DEBUG]: {default_config_data}")
+    return default_config_data
+
+def get_resource_ports(resource):
+    """Extracts ports from a resource definition."""
+    ports = []
+    object = resource.get('object', {})
+    spec = object.get('spec', {})
+    template = spec.get('template', {})
+    spec_template = template.get('spec', {})
+    containers = spec_template.get('containers', [])
+
+    for container in containers:
+        container_ports = container.get('ports', [])
+        for port in container_ports:
+            ports.append(port.get('containerPort'))
+    print(f"[DEBUG] Resource: {resource.get('resourceID', 'Unknown')}, Ports: {ports}")
+    return ports
+
+def get_resource_images(resource):
+    """Extracts container images from a resource definition."""
+    images = []
+    object = resource.get('object', {})
+    spec = object.get('spec', {})
+    template = spec.get('template', {})
+    spec_template = template.get('spec', {})
+    containers = spec_template.get('containers', [])
+
+    for container in containers:
+        image = container.get('image', '')
+        if image:
+            images.append(image)
+    print(f"[DEBUG] Resource: {resource.get('resourceID', 'Unknown')}, Images: {images}")
+    return images
+
+def get_status_emoji(status):
+    """Returns the emoji for a given status."""
+    return '✅' if status == 'passed' else '❌'
+
+def generate_markdown_tables(data, config):
+    """Generates markdown tables for each resourceID."""
+    print(f"[DEBUG] Generating markdown tables with config: {config}")
+    results = data.get('results', [])
+    print(f"[DEBUG] Total results found: {len(results)}")
+    resources = data.get('resources', [])
+    print(f"[DEBUG] Total resources found: {len(resources)}")
+
+    # get mandatory checks list from config file
+    mandatory_checks = [
+        rule_id
+        for rule_id, rule_data in config.get('hardening_rules', {}).items()
+        if rule_data.get('mandatory') is True
+    ]
+    print(f"[DEBUG] Mandatory checks from config: {mandatory_checks}")
+    if not results:
+        return "No results found in the JSON data."
+    failed_mandatory_checks_all = {}
+    output_lines = []
+    for resource in results:
+        resource_id = resource.get('resourceID', 'Unknown')
+        if not '/Deployment/' in resource_id:  # Skip non-deployment resources
+            continue
+        resource_data = next((r for r in resources if r.get('resourceID') == resource_id), {})
+        resource_ports = get_resource_ports(resource_data)
+        resource_images = get_resource_images(resource_data)
+        controls = resource.get('controls', [])
+        failed_mandatory_checks = []
+
+        # Resource header
+        output_lines.append(f"\n## Resource: `{resource_id}`\n")
+        output_lines.append("| ControlID | Control name | Status |")
+        output_lines.append("|-----------|--------------|--------|")
+
+        # Processing each control
+        for control in controls:
+            control_id = control.get('controlID', '')
+            control_name = control.get('name', '')
+            rules = control.get('rules', [])
+
+            # Each rule in a separate line.
+            if len(rules) > 1:
+                for rule in rules:
+                    status = rule.get('status', '')
+                    status_emoji = get_status_emoji(status)
+                    output_lines.append(f"| {control_id} | {control_name} ({rule.get('name', '')}) | {status_emoji} |")
+                    if control_id in mandatory_checks and status != 'passed' and control_id not in failed_mandatory_checks:
+                        failed_mandatory_checks.append(control_id)
+            else:
+                # Normal case - single rule
+                status = rules[0].get('status', '') if rules else control.get('status', {}).get('status', '')
+                status_emoji = get_status_emoji(status)
+                output_lines.append(f"| {control_id} | {control_name} | {status_emoji} |")
+                if control_id in mandatory_checks and status != 'passed':
+                    failed_mandatory_checks.append(control_id)
+
+        # compare resource ports with prohibited ports list from config file and add a line to the table if there is a match.
+        ports_check_success = 0
+        ports_intersection = list(set(config.get('hardening_rules', {}).get('Critical-Ports', {}).get('critical_ports', [])) & set(resource_ports))
+        if ports_intersection:
+            output_lines.append(f"| Critical-Ports | Critical Ports: {', '.join(map(str, sorted(ports_intersection)))} | ❌ |")
+            if 'Critical-Ports' in mandatory_checks:
+                failed_mandatory_checks.append('Critical-Ports')
+        else:
+            output_lines.append("| Critical-Ports | Critical Ports | ✅ |")
+            ports_check_success += 1
+        # check if any of the container images used in the resource are using the 'latest' tag and add a line to the table if there is a match.
+        latest_images_check_success = 0
+        latest_images = [img for img in resource_images if img.endswith(':latest')]
+        if latest_images:
+            output_lines.append(f"| Latest-Tag | Images using 'latest' tag: {', '.join(latest_images)} | ❌ |")
+            if 'No-Latest-Tag' in mandatory_checks:
+                failed_mandatory_checks.append('No-Latest-Tag')
+        else:
+            output_lines.append("| Latest-Tag | No images using 'latest' tag | ✅ |")
+            latest_images_check_success += 1
+
+        # Add statistics for the resource
+        total_controls = len(controls) + 2  # +2 for Critical-Ports and Latest-Tag checks
+        passed = sum(1 for c in controls
+                    if c.get('rules', [{}])[0].get('status', '') == 'passed') + ports_check_success + latest_images_check_success
+        failed = total_controls - passed
+
+        output_lines.append(f"\n**Total:** ✅ passed: {passed}, ❌ failed: {failed}\n")
+        output_lines.append(f"**Failed mandatory checks:** {', '.join(failed_mandatory_checks) if failed_mandatory_checks else 'None'}\n")
+        output_lines.append("---")
+
+        failed_mandatory_checks_all[resource_id] = failed_mandatory_checks
+
+    return '\n'.join(output_lines), failed_mandatory_checks_all
+
+def generate_full_report(data, config, title="Kubescape Hardening Scan Report"):
+    """Generates a full markdown report."""
+    print(f"[DEBUG] Generating full report with title: {title}")
+    timestamp = __import__('datetime').datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+    report = f"""# {title}
+
+**Generation date:** {timestamp}
+
+## Summary by resources
+
+"""
+
+    results = data.get('results', [])
+    for resource in results:
+        resource_id = resource.get('resourceID', 'Unknown')
+        if not '/Deployment/' in resource_id:  # Skip non-deployment resources
+            continue
+
+        controls = resource.get('controls', [])
+        passed = sum(1 for c in controls
+                    if c.get('rules', [{}])[0].get('status', '') == 'passed')
+        failed = len(controls) - passed
+        report += f"- `{resource_id}`: ✅ {passed} / ❌ {failed}\n"
+
+    report += "\n---\n"
+    report_tables, failed_mandatory_checks_all = generate_markdown_tables(data, config)
+    report += report_tables
+
+    return report, failed_mandatory_checks_all
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Converts kubescape JSON results into Markdown tables.'
+    )
+    parser.add_argument(
+        '--input', '-i',
+        help='Path to the JSON file or URL (default: specified URL)'
+    )
+    parser.add_argument(
+        '--output', '-o',
+        default='kubescape-report.md',
+        help='Path for saving the markdown file (default: kubescape-report.md)'
+    )
+    parser.add_argument(
+        '--title', '-t',
+        default='Kubescape Hardening Scan Report',
+        help='Report title'
+    )
+    parser.add_argument(
+        '--config', '-c',
+        default='.github/hardening-config.yaml',
+        help='Path to the YAML configuration file (default: .github/hardening-config.yaml)'
+    )
+
+    args = parser.parse_args()
+
+    try:
+        config = load_yaml_config(args.config)
+        print(f"Loading data from: {args.input}")
+        data = load_json_data(args.input)
+
+        print("Generating markdown report...")
+        report, failed_mandatory_checks_all = generate_full_report(data, config, args.title)
+
+        with open(args.output, 'w', encoding='utf-8') as f:
+            f.write(report)
+
+        print(f"✅ Report successfully saved to: {args.output}")
+
+        # Display brief statistics
+        results = data.get('results', [])
+        print(f"\n📊 Statistics:")
+        print(f"   Total resources: {len(results)}")
+        for resource in results:
+            resource_id = resource.get('resourceID', 'Unknown')
+            controls = resource.get('controls', [])
+            passed = sum(1 for c in controls
+                        if c.get('rules', [{}])[0].get('status', '') == 'passed')
+            print(f"   - {resource_id}: {passed}/{len(controls)} passed")
+        if failed_mandatory_checks_all:
+            print("\n⚠️  Failed mandatory checks:")
+            for resource_id, checks in failed_mandatory_checks_all.items():
+                if checks:
+                    print(f"   - {resource_id}: {', '.join(checks)}")
+            # Count total failed mandatory checks across all resources
+            total_failed_mandatory_checks = sum(len(v) for v in failed_mandatory_checks_all.values())
+            print(f"\nTotal failed mandatory checks: {total_failed_mandatory_checks}")
+            # If there are failed mandatory checks, save them to a JSON file for further processing in the workflow
+            if total_failed_mandatory_checks > 0:
+                with open('failed_mandatory_checks.json', 'w', encoding='utf-8') as f:
+                    json.dump(failed_mandatory_checks_all, f, indent=2)
+    except Exception as e:
+        print(f"❌ Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/docs/actions-workflows-catalog.md
+++ b/docs/actions-workflows-catalog.md
@@ -27,6 +27,7 @@ Deprecation & evolution rules are defined in [Standards & Change Policy](standar
 | [docker-action](../actions/docker-action/README.md)                             | Build & push (multi-platform) Docker images                  |
 | [docker-config-resolver](../actions/docker-config-resolver/README.md)           | Load, validate, and normalize Docker component configuration |
 | [ghcr-discover-repo-packages](../actions/ghcr-discover-repo-packages/README.md) | Discover and list all GHCR packages for a repository         |
+| [k8s-hardening-scan](../actions/k8s-hardening-scan/README.md)                   | Validate container hardening compliance for Kubernetes deployments |
 | [maven-release](../actions/maven-release/README.md)                             | Run Maven release scripting (docs WIP)                       |
 | [maven-snapshot-deploy](../actions/maven-snapshot-deploy/README.md)             | Deploy Maven SNAPSHOT artifacts                              |
 | [metadata-action](../actions/metadata-action/README.md)                         | Produce version / tag metadata outputs                       |

--- a/docs/actions-workflows-catalog.md
+++ b/docs/actions-workflows-catalog.md
@@ -4,11 +4,12 @@ Central directory of available GitHub Actions and Reusable Workflows in this rep
 
 Purpose:
 
-* Single place to browse everything (active + deprecated) with short descriptions.
-* Shows deprecation status so you avoid adopting legacy components.
-* Fast jumping-off point to each Action / Workflow detail readme.
+- Single place to browse everything (active + deprecated) with short descriptions.
+- Shows deprecation status so you avoid adopting legacy components.
+- Fast jumping-off point to each Action / Workflow detail readme.
 
-Deprecation & evolution rules are defined in [Standards & Change Policy](standards-and-change-policy.md). Always check that document before modifying or depending on a deprecated component.
+Deprecation & evolution rules are defined in [Standards & Change Policy](standards-and-change-policy.md).
+Always check that document before modifying or depending on a deprecated component.
 
 ---
 


### PR DESCRIPTION
# Pull Request

## Summary

Adds a new composite action `k8s-hardening-scan` that validates container hardening compliance
for Kubernetes deployments. The action runs Kubescape scans (NSA, MITRE, DevOpsBest frameworks)
against specified namespaces, generates a per-Deployment markdown report posted to the step
summary, and optionally runs Trivy misconfiguration scans on Helm chart sources. Mandatory
hardening rules are configurable and can gate the workflow on failure.

## Issue

Closes #684

## Breaking Change?

- [ ] Yes
- [x] No

## Scope / Project

`actions/k8s-hardening-scan`

## Implementation Notes

- Composite action with no build step — logic lives in `action.yaml` steps and `report-generator.py`
- `report-generator.py` reads Kubescape JSON output, merges it with a bundled `hardening-config.yaml`
  defining mandatory rules, and generates per-Deployment markdown tables with pass/fail per control
- Custom caller config (`.github/hardening-config.yaml`) supports an `ignored_checks` list to
  downgrade specific rules from mandatory to informational
- Two additional custom checks beyond Kubescape controls: `Critical-Ports` (blocks well-known
  service ports) and `No-Latest-Tag` (blocks `latest` image tags)
- All `uses:` references in `action.yaml` are SHA-pinned per repo security policy
- `actions/checkout` uses `persist-credentials: false` to prevent credential leakage into artifacts

## Tests / Evidence

- New composite action with no unit tests (no Node.js build)
- Action logic verified by reading `action.yaml` steps and `report-generator.py` source
- Documentation generated and synced to `actions/k8s-hardening-scan/README.md` and catalog

## Additional Notes

- Requires a configured kubeconfig on the runner before this action is called
- Kubescape is installed at a pinned SHA (`1d5520f7`) in the install step
- The `execute-trivy-scan` input defaults to `false`; enable it to also scan Helm chart sources