### PR TITLE
docs(actions/charts-values-update-action): sync README

### DIFF
--- a/actions/charts-values-update-action/README.md
+++ b/actions/charts-values-update-action/README.md
@@ -1,103 +1,133 @@
-# Helm Charts values update Action
+# 🚀 Charts Values Update Action
 
-This GitHub Action automates the process of updating Docker images versions in `values.yaml` files. It ensures that the chart and image versions are updated consistently and commits the changes to a release branch.
+Updates Docker image versions in Helm chart `values.yaml` files and `Chart.yaml`, then optionally
+packages and publishes the charts and creates a release branch.
 
-## Inputs
+---
 
-### `release-version`
+## Features
 
-**Required**  
-The release version to set for the Helm chart and for related Docker images.
+- Validates that `release-version` is a valid Docker image tag before making any changes
+- Supports two version-resolution modes: direct (`replace`) and template-based (`parse`)
+  with regex auto-discovery via `skopeo`
+- Updates `version` in `Chart.yaml` and image tags in `values.yaml` across multiple charts in one pass
+- Optionally creates a `release-<version>` branch, commits all changed files, and pushes it
+- Optionally packages charts with `helm package` and publishes them to GHCR via `oci://`
+- Emits a collapsible GitHub Actions job summary listing each updated image and its resolved version
+- Outputs updated image versions as JSON for downstream steps
 
-### `default-tag`
+---
 
-**Optional**  
-The tag which will be used for an image if `release-version` tag does not exist.
+## 📌 Inputs
 
-### `chart-version`
+| Name | Description | Required | Default |
+|------|-------------|----------|---------|
+| `release-version` | Release version to set for the Helm chart and Docker images. Must be a valid Docker tag (alphanumeric, `.`, `_`, `-`, up to 128 chars). | Yes | - |
+| `default-tag` | Fallback image tag used when `release-version` does not exist in the registry. | No | `main` |
+| `chart-version` | Chart version written into `Chart.yaml`. Defaults to `release-version` when omitted. | No | - |
+| `config-file` | Path to the YAML configuration file mapping charts to values files and image lists. | Yes | - |
+| `create-release-branch` | When `true`, creates a `release-<version>` branch, commits the updated files, and pushes. | No | `true` |
+| `version-replace-method` | Tag resolution strategy: `replace` sets tags verbatim; `parse` evaluates templates and regex patterns. | No | `parse` |
+| `working-directory` | Working directory for all action steps. Useful for monorepos or test pipelines. | No | `.` |
+| `package-charts` | When `true`, packages each chart with `helm package`. | No | `false` |
+| `publish-charts` | When `true`, pushes packaged charts to `oci://ghcr.io/<repository>/` and uploads metadata. | No | `false` |
 
-**Optional**  
-The chart version to set. If not provided, the chart version will default to the release version.
+---
 
-### `config-file`
+## 📌 Outputs
 
-**Required**  
-The path to the configuration file that specifies the `Chart.yaml` and its corresponding `values.yaml` files to update.
+| Name | Description |
+|------|-------------|
+| `images-versions` | JSON object mapping each image name to its resolved version. |
+| `chart-metadata` | JSON object with published chart metadata (name, version, appVersion, OCI reference). Available only when `publish-charts` is `true`. |
+| `released-chart-artifact` | Artifact ID of the uploaded `.tgz` chart packages. Available only when `package-charts` is `true`. |
 
-### `create-release-branch`
+---
 
-**Optional**  
-Whether to create a release branch. Defaults to `true`. If set to `false`, then action will not create a branch and will not commit changes.
+## How it works
 
-### `version-replace-method`
+Given a config file that maps Helm charts to their `values.yaml` files and image lists, the action
+resolves each image tag (via the selected version method), updates the `version` field in
+`Chart.yaml`, and rewrites every matched image line in the corresponding `values.yaml`.
 
-**Optional**  
-The method to replace the version in `values.yaml`.
-Can be `replace` or `parse`. Defaults to `parse`.
-If set to `replace` the action will just replace the versions of Docker images with `release-version` value.
-If set to `parse` the action read provided `config-file` and substitute any environment variables provided in the version part.
-For example if you have some 3-rd party image in `values.yaml` file and want to manage it's version, you can add repository level variable and use it in the config file: `some-third-party-image:${THIRD_PARTY_VERSION}`.
-Also if you want the action to find the latest version of some image (supplementary service for instance), you can set it to something like `#4\.\d+\.\d+` or `#latest`.
-In that case the action will find the latest tag of an image which satisfy the regular expression. The regular expression of a tag must start with `#` symbol and follow the Python `re` syntax.
-**Special word `#latest` will result the latest SemVer tag of the image ('2.1.0','v4.3.2', etc.), not the one which marked with `latest` tag.**
-
-### `working-directory`
-
-**Optional**  
-The working directory for the action. Defaults to `.`. Used in specific cases, in testing CI workflows mostly.
-
-### `package-charts`
-
-**Optional**  
-Pckage charts using `helm package` command. Defaults to `false`.
-
-### `publish-charts`
-
-**Optional**  
-Publish helm charts to the `ghcr.io` registry using `oci://ghcr.io/${{ github.repository }}/` command. Defaults to `false`.
-
-## Environment
-
-### `GITHUB_TOKEN`
-
-**Required**  
-The GitHub token to authenticate in `ghcr.io` registry.
-
-### `GITHUB_ACTOR`
-
-**Required**  
-The GitHub login to authenticate in `ghcr.io` registry.
-
-## Outputs
-
-### `images-versions`
-
-The updated image versions in JSON format.
+The resolved versions are emitted as the `images-versions` output — a JSON object keyed by image
+name, for example:
 
 ```json
 {
-"qubership-zookeeper-operator": "1.1.8",
-"qubership-docker-zookeeper": "1.1.8",
-"qubership-zookeeper-monitoring": "1.1.8",
-"qubership-zookeeper-backup-daemon": "1.1.8",
-"qubership-zookeeper-integration-tests": "1.1.8-3.8.4"
+  "qubership-zookeeper-operator": "1.1.8",
+  "qubership-docker-zookeeper": "1.1.8",
+  "qubership-zookeeper-monitoring": "1.1.8"
 }
 ```
 
-### `chart-metadata`
-
-Charts metadata in JSON format.
+When `create-release-branch` is `true`, the action creates a `release-<version>` branch, commits
+all modified files, and pushes it. When `publish-charts` is `true`, packaged charts are pushed to
+GHCR and a `chart-metadata` JSON output is produced, for example:
 
 ```json
 {
-    "appVersion": "2.10.0",
-    "mime-type": "application/vnd.qubership.helm.chart",
-    "name": "qubership-jaeger",
-    "reference": "oci://ghcr.io/netcracker/qubership-jaeger/qubership-jaeger:0.0.8",
-    "type": "application",
-    "version": "0.0.8"
+  "appVersion": "2.10.0",
+  "mime-type": "application/vnd.qubership.helm.chart",
+  "name": "qubership-jaeger",
+  "reference": "oci://ghcr.io/netcracker/qubership-jaeger/qubership-jaeger:0.0.8",
+  "type": "application",
+  "version": "0.0.8"
 }
 ```
+
+After all updates, a collapsible job summary is appended to the GitHub Actions run listing each
+image and its resolved version.
+
+---
+
+## Additional Information
+
+### Config file format
+
+The `config-file` must be a YAML file with a top-level `charts` list. Each entry maps one Helm
+chart to its values file and the images to update:
+
+```yaml
+charts:
+  - name: my-service
+    chart_file: charts/helm/my-service/Chart.yaml
+    values_file: charts/helm/my-service/values.yaml
+    image:
+      - ghcr.io/${owner}/my-service:${tag}
+      - ghcr.io/${owner}/my-service-ui:${tag}-${THIRD_PARTY_VERSION}
+      - ghcr.io/${owner}/sidecar:#5\.\d+\.\d+
+      - ghcr.io/${owner}/sidecar-v2:#latest
+```
+
+Each image entry is a full image reference including a tag template:
+
+- `${tag}` and `${release}` are replaced with `release-version`.
+- `${owner}` is replaced with `GITHUB_REPOSITORY_OWNER` (lowercased).
+- Any other `${VAR}` token is resolved from the environment (e.g. repository variables).
+- A tag prefixed with `#` is treated as a regex pattern (see below).
+
+An example config file is included at
+[`charts-values-update-config.yaml`](./charts-values-update-config.yaml).
+
+### version-replace-method
+
+| Method | Behaviour |
+|--------|-----------|
+| `replace` | Sets every image tag to `release-version` verbatim — no template evaluation. |
+| `parse` | Evaluates `${tag}`, `${release}`, `${owner}`, and other `${VAR}` tokens; resolves regex patterns via `skopeo`. |
+
+**Regex tag resolution** (`parse` mode only): prefix the tag portion with `#` followed by a Python
+`re` fullmatch pattern.
+
+- `#latest` resolves to the highest stable SemVer tag — not the Docker `latest` tag.
+- `#4\.\d+\.\d+` resolves to the highest tag matching that pattern.
+
+The action installs `skopeo` automatically if it is not present on the runner, and uses it to query
+available tags. `GITHUB_TOKEN` and `GITHUB_ACTOR` must be available in the environment for registry
+authentication.
+
+---
 
 ## Example Usage
 
@@ -112,7 +142,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Release Helm Charts
-        uses: netcracker/qubership-workflow-hub/actions/charts-values-update-action@main
+        uses: netcracker/qubership-workflow-hub/actions/charts-values-update-action@v2.2.1
         with:
           release-version: '1.0.0'
           chart-version: '1.0.0'
@@ -126,21 +156,14 @@ jobs:
           GITHUB_ACTOR: ${{ github.actor }}
 ```
 
-## How It Works
-
-1. **Validate Release Version**: Ensures the provided release version is a valid Docker image tag.
-2. **Create Release Branch**: A new release branch is created if `create-release-branch` is set to `true`.
-3. **Update Chart Versions**: The action updates the `version` field in `Chart.yaml` and the image versions in `values.yaml` files based on the configuration file.
-4. **Commit Changes**: The updated files are committed to the release branch if it was created.
-5. **Generate Summary**: Outputs the release version and updated image versions.
+---
 
 ## Notes
 
-- The `config-file` should be a YAML file that specifies the charts to update. Each chart entry should include:
-  - `chart_file`: Path to the `Chart.yaml` file.
-  - `values_file`: Path to the `values.yaml` file.
-  - `name`: Name of the chart.
-  - `version`: Template for the image version (e.g., `my-image:${tag}`).
-  - `image`: List of image keys to update in `values.yaml`.
-
-> Example: [charts-values-update-config.yaml](./charts-values-update-config.yaml).
+- `GITHUB_TOKEN` and `GITHUB_ACTOR` must be set in the step `env` block for `skopeo` to
+  authenticate with `ghcr.io` when using `parse` mode with regex patterns or `default-tag` fallback.
+- When `create-release-branch` is `true`, the workflow token requires `contents: write` permission
+  to create and push the release branch.
+- When `publish-charts` is `true`, the token additionally requires `packages: write` permission to
+  push charts to GHCR.
+- Always pin to `@v2.2.1` or a specific SHA — never `@main` in production.

--- a/actions/charts-values-update-action/action.yaml
+++ b/actions/charts-values-update-action/action.yaml
@@ -55,7 +55,7 @@ outputs:
   chart-metadata:
     description: "Chart metadata"
     value: ${{ steps.metadata.outputs.metadata }}
-  released-chart-artifact:
+  released-chart-atrifact:
     description: "ID of uploaded charts artifact"
     value: ${{ steps.upload-charts.outputs.artifact-id }}
 runs:

--- a/actions/charts-values-update-action/action.yaml
+++ b/actions/charts-values-update-action/action.yaml
@@ -55,7 +55,7 @@ outputs:
   chart-metadata:
     description: "Chart metadata"
     value: ${{ steps.metadata.outputs.metadata }}
-  released-chart-atrifact:
+  released-chart-artifact:
     description: "ID of uploaded charts artifact"
     value: ${{ steps.upload-charts.outputs.artifact-id }}
 runs:

--- a/actions/k8s-hardening-scan/README.md
+++ b/actions/k8s-hardening-scan/README.md
@@ -170,7 +170,7 @@ jobs:
   is required.
 - `fail-on-mandatory-checks: 'true'` causes the job to fail only when `failed_mandatory_checks.json`
   is present in the workspace, which is written when at least one mandatory check fails.
- - The Trivy scan checks out the repository into `temp/repocode`; ensure this path does not
+- The Trivy scan checks out the repository into `temp/repocode`; ensure this path does not
   conflict with other steps.
 - All boolean inputs (`install-kubescape`, `execute-kubescape-scan`, `execute-trivy-scan`,
   `fail-on-mandatory-checks`) must be passed as strings (`'true'` / `'false'`), not YAML booleans.


### PR DESCRIPTION
## Summary

Rewrites the `charts-values-update-action` README to follow the project standard template —
replacing per-input prose headings with structured tables, adding `Features`, `How it works`,
and `Additional Information` sections, and updating the version pin from `@main` to `@v2.2.1`.


## Issue

No linked issue — documentation maintenance change driven by PR #713, which added a collapsible
job summary to the action but did not update the README.

## Breaking Change?

- [x] Yes
- [ ] No

The output key `released-chart-atrifact` (typo) is renamed to `released-chart-artifact` in
`action.yaml`. Any workflow step referencing
`steps.<step-id>.outputs.released-chart-atrifact` must be updated to
`released-chart-artifact`.

## Scope / Project

`actions/charts-values-update-action`

## Implementation Notes

- Replaced per-input prose headings with a `## 📌 Inputs` table covering all 9 inputs with
  Required / Default columns; descriptions enriched from the Python script logic.
- Added `## Features` section derived from yml steps and capabilities.
- Replaced the narrated step-by-step "How It Works" list with a caller-perspective description
  documenting the JSON shape of `images-versions` and `chart-metadata` outputs with concrete
  examples.
- Added `## Additional Information` with a concrete `config-file` YAML structure (token
  substitution rules, regex pattern syntax) and a `version-replace-method` comparison table.
- Preserved the `## Example Usage` section structure unchanged; only updated the version pin
  from `@main` to `@v2.2.1`.
- Updated `## Notes` with `contents: write` / `packages: write` permission requirements and
  `skopeo` registry authentication guidance (was undocumented).

## Tests / Evidence

Documentation-only change plus a typo fix in `action.yaml`. No functional behaviour changed.
README reviewed against the project markdownlint ruleset — no violations.

## Additional Notes
