### PR TITLE
docs(actions): rewrite READMEs for maven-snapshot-deploy and maven-release

### DIFF
--- a/actions/maven-release/README.md
+++ b/actions/maven-release/README.md
@@ -1,81 +1,201 @@
 # 🚀 Maven Release Action
 
-This GitHub Action automates the process of building and releasing a Maven artifact. It supports version bumping (major, minor, patch), GPG signing, and optional dependency version bumping after release.
+Automates building and releasing a Maven artifact for a repository within the same GitHub
+organization. Handles version bumping (major, minor, or patch), GPG signing, Maven release
+preparation and perform, and optional post-release dependency snapshot bumping.
 
 ---
 
 ## Features
 
-- **Automatic Version Bumping:** Supports major, minor, and patch version increments for Maven artifacts.
-- **Branch Selection:** Allows releasing from any branch (default is `main`).
-- **GPG Signing:** Signs artifacts using provided GPG keys and passphrase.
-- **Custom Maven Arguments:** Pass additional Maven arguments for flexible builds.
-- **Dry Run Support:** Optionally perform a dry run without pushing changes.
-- **Dependency Snapshot Bumping:** Optionally bumps dependencies to the next snapshot version after release.
-- **Custom Profiles and Credentials:** Supports custom Maven profiles, usernames, and passwords for publishing.
+- Validates `version-type` (`major`, `minor`, `patch`) and required inputs before proceeding
+- Validates Maven `groupId` across all `pom.xml` files against a forbidden-groupId policy
+  (`org.qubership`, `com.netcracker` exact matches are blocked)
+- Bumps the project version automatically based on `version-type` and runs `mvn release:prepare`
+  + `mvn release:perform`
+- Supports **dry-run** mode: builds and deploys the current SNAPSHOT version without tagging or
+  pushing any changes
+- Signs artifacts via GPG using `actions/setup-java` key import
+- Caches the local Maven repository (`~/.m2/repository`) across runs
+- Optionally pins a specific Maven version via `stCarolas/setup-maven`
+- Optionally bumps dependencies to the next `-SNAPSHOT` version after release
+  (`bump-dependencies-after-release`)
+- Exposes the released version as the `release-version` output
+- Reports build and release progress to the workflow step summary
+
+---
 
 ## 📌 Inputs
 
-| Name                        | Description                                                                                       | Required | Default                                                    |
-|-----------------------------|---------------------------------------------------------------------------------------------------|----------|------------------------------------------------------------|
-| `version-type`              | Type of version bump for the release. Can be one of: `major`, `minor`, `patch`.                  | Yes      | `patch`                                                    |
-| `module`                    | The module (repository name) to build.                                                            | Yes      |                                                            |
-| `ref`                       | Branch name to create the release from.                                                           | No       | `main`                                                     |
-| `maven-args`                | Additional Maven arguments to pass.                                                               | No       | `-DskipTests=true -Dmaven.javadoc.skip=true -B`            |
-| `server-id`                 | Maven server ID.                                                                                  | No       | `github`                                                   |
-| `java-version`              | Java version to use.                                                                              | No       | `21`                                                       |
-| `maven-version`             | Maven version to use.                                                                             | No       |                                                            |
-| `dry-run`                   | If set to `true`, performs a dry run without pushing changes.                                     | No       | `true`                                                     |
-| `token`                     | GitHub token for authentication.                                                                  | Yes      |                                                            |
-| `gpg-private-key`           | GPG private key for signing artifacts.                                                            | Yes      |                                                            |
-| `gpg-passphrase`            | Passphrase for the GPG private key.                                                               | Yes      |                                                            |
-| `profile`                   | Maven profile to use.                                                                             | No       |                                                            |
-| `maven-user`                | Username to login to Maven central or GitHub packages.                                            | No       |                                                            |
-| `maven-password`            | Password to login to Maven central or GitHub packages.                                            | No       |                                                            |
-| `bump-dependencies-after-release` | If set to `true`, bumps dependencies versions to the next snapshot after release.         | No       | `false`                                                    |
+| Name | Description | Required | Default |
+| --- | --- | --- | --- |
+| `version-type` | Version bump type for the release: `major`, `minor`, or `patch`. | Yes | `patch` |
+| `module` | Repository name to release. The action checks out `<org>/<module>` using the provided token. | Yes | - |
+| `ref` | Branch to create the release from. | No | `main` |
+| `maven-args` | Additional Maven arguments appended to every Maven invocation. | No | `-DskipTests=true -Dmaven.javadoc.skip=true -B` |
+| `server-id` | Maven server ID configured in `~/.m2/settings.xml` by `actions/setup-java`. | No | `github` |
+| `java-version` | JDK version to use. | No | `21` |
+| `maven-version` | Maven version to install. When empty, the runner's pre-installed Maven is used. | No | - |
+| `dry-run` | Set to `'false'` to perform an actual release. Any other value (including the default `'true'`) runs in dry-run mode. | No | `true` |
+| `token` | GitHub token used for repository checkout and git push during release. | Yes | - |
+| `gpg-private-key` | Armored GPG private key for signing artifacts. | Yes | - |
+| `gpg-passphrase` | Passphrase for the GPG private key. | Yes | - |
+| `profile` | Maven profile to activate (passed as `-P<profile>`). Leave empty to skip profile activation. | No | - |
+| `maven-user` | Username for Maven registry authentication (`MAVEN_USERNAME`). | No | - |
+| `maven-password` | Password for Maven registry authentication (`MAVEN_PASSWORD`). | No | - |
+| `bump-dependencies-after-release` | Set to `'true'` to bump `org.qubership.cloud*` and `org.qubership.core*` dependencies to their next `-SNAPSHOT` versions and commit the updated `pom.xml` after a successful release. Ignored in dry-run mode. | No | `false` |
+
+---
 
 ## 📌 Outputs
 
-### `release-version`
+| Name | Description |
+| --- | --- |
+| `release-version` | The version that was built or released (e.g. `2.1.0`). Set in both dry-run and actual release modes. |
 
-The version that was released.
+---
 
-## Example Usage
+## How it works
+
+The action targets a repository within the same GitHub organization. It checks out
+`<org>/<module>` (not the calling repository) using the provided `token`, then runs the full
+Maven Release Plugin flow:
+
+**In dry-run mode** (default, `dry-run != 'false'`): the action builds and deploys the current
+SNAPSHOT version as-is with `mvn deploy`. No version is bumped, no tag is created, and no git
+commits are pushed. The `release-version` output is set to the current project version. This is
+useful for validating that the build and deployment pipeline is healthy before committing to a
+release.
+
+**In actual release mode** (`dry-run: 'false'`):
+
+1. `mvn versions:use-releases` — replaces any SNAPSHOT dependency references with their release
+   equivalents.
+1. `mvn release:prepare` — computes the new release version (based on `version-type`), creates a
+   git tag in the format `v<version>`, commits the bumped `pom.xml`, and pushes both the commit
+   and tag to the remote.
+1. `mvn release:perform` — checks out the tag and deploys the signed artifact to the configured
+   Maven registry.
+1. (Optional) If `bump-dependencies-after-release` is `'true'`: checks out `main` of the same
+   module, runs `mvn versions:use-next-snapshots` to update `org.qubership.cloud*` and
+   `org.qubership.core*` dependencies to their next `-SNAPSHOT` versions, and commits the result
+   with `[skip ci]`.
+
+The `release-version` output holds the released version in both modes (e.g. `2.1.0`).
+
+---
+
+## Additional Information
+
+### Version bumping logic
+
+Given a current version such as `2.1.3-SNAPSHOT`:
+
+| `version-type` | Resulting release version |
+| --- | --- |
+| `patch` | `2.1.3` (Maven Release Plugin default — no explicit `-DreleaseVersion`) |
+| `minor` | `2.2.0` |
+| `major` | `3.0.0` |
+
+The patch bump relies entirely on the Maven Release Plugin's default behaviour. Major and minor
+bumps pass an explicit `-DreleaseVersion` flag.
+
+### `module` and cross-repository checkout
+
+The `module` input must match the repository name exactly (not the full slug). The action
+constructs the checkout URL as:
+
+```text
+github.repository_owner/<module>
+```
+
+This means the action can release a **different repository** from the one running the workflow,
+as long as the `token` has write access to that repository. This is the intended use case when
+this action is called from a central release orchestration workflow.
+
+### `dry-run` default
+
+The default value of `dry-run` is `'true'` (a string). The action only enters actual release
+mode when `dry-run` is the exact string `'false'`. Any other value — including `true`, `'true'`,
+or an empty string — triggers dry-run mode.
+
+### Maven groupId policy
+
+Before the release step, the action scans every `pom.xml` (excluding `target/`) and fails if
+any module declares a `groupId` of exactly `org.qubership` or `com.netcracker`. Sub-packages
+(e.g. `org.qubership.cloud`) are permitted. Failures are reported as GitHub Actions errors
+with the offending file path.
+
+### GPG signing
+
+`gpg-private-key` and `gpg-passphrase` are required inputs (even for dry-run builds, since the
+action deploys a SNAPSHOT artifact). They are imported by `actions/setup-java` and consumed
+automatically by the Maven GPG plugin during deployment.
+
+### `bump-dependencies-after-release`
+
+This step only runs when **both** `dry-run == 'false'` and `bump-dependencies-after-release == 'true'`.
+It is silently skipped in dry-run mode. The dependency filter is hardcoded to
+`org.qubership.cloud*:*,org.qubership.core*:*` — only those groups are bumped to their next
+SNAPSHOT.
+
+---
+
+## Usage
 
 ```yaml
 name: Maven Release
 
 on:
   workflow_dispatch:
+    inputs:
+      version-type:
+        description: 'Version bump type'
+        required: true
+        default: 'patch'
+        type: choice
+        options: [major, minor, patch]
+      dry-run:
+        description: 'Dry run (no tag or push)'
+        required: false
+        default: 'true'
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Release Maven Artifact
-        uses: netcracker/qubership-workflow-hub/actions/maven-release@main
+        uses: netcracker/qubership-workflow-hub/actions/maven-release@v2.2.1
         with:
-          version-type: 'minor'
+          version-type: ${{ inputs.version-type }}
           module: 'my-module'
           ref: 'main'
+          dry-run: ${{ inputs.dry-run }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          gpg-passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
           maven-user: ${{ secrets.MAVEN_USER }}
           maven-password: ${{ secrets.MAVEN_PASSWORD }}
           bump-dependencies-after-release: 'true'
 ```
 
-## How It Works
-
-1. **Input Validation**: Checks required inputs and validates version type and module.
-2. **Setup**: Configures Java and Maven environments.
-3. **Checkout**: Clones the specified module and branch.
-4. **Release**: Bumps the version, builds, and releases the artifact. Optionally bumps dependencies to the next snapshot version.
-5. **Cleanup**: Cleans up workspace if dependency bumping is enabled.
+---
 
 ## Notes
 
-- Ensure project pom.xml file configured according [pom preparation instruction](https://github.com/Netcracker/.github/blob/main/docs/maven-publish-pom-preparation_doc.md)
-- Ensure all required secrets are available in your repository.
-- The action supports both dry-run and actual release modes.
+- `dry-run` defaults to `'true'` — you must explicitly pass `dry-run: 'false'` to perform an
+  actual release. Any typo or omission will silently result in a dry run.
+- The `token` must have write access to `<org>/<module>` to push tags and commits during release.
+  `secrets.GITHUB_TOKEN` only has write access to the calling repository; use a PAT for
+  cross-repository releases.
+- `gpg-private-key` and `gpg-passphrase` are required even for dry-run builds because the action
+  deploys a SNAPSHOT artifact.
+- Ensure `pom.xml` is configured according to the
+  [pom preparation guide](https://github.com/Netcracker/.github/blob/main/docs/maven-publish-pom-preparation_doc.md).
+- Organization-level secrets for Maven are documented in the
+  [secrets guide](https://github.com/Netcracker/.github/blob/main/docs/maven-publish-secrets_doc.md).
+- All `dry-run`, `bump-dependencies-after-release`, and `upload-artifact` inputs are strings,
+  not booleans — pass `'true'` or `'false'` (quoted).
+- Always pin to `@v2.2.1` or a specific SHA — never `@main` in production.

--- a/actions/maven-release/README.md
+++ b/actions/maven-release/README.md
@@ -11,8 +11,7 @@ preparation and perform, and optional post-release dependency snapshot bumping.
 - Validates `version-type` (`major`, `minor`, `patch`) and required inputs before proceeding
 - Validates Maven `groupId` across all `pom.xml` files against a forbidden-groupId policy
   (`org.qubership`, `com.netcracker` exact matches are blocked)
-- Bumps the project version automatically based on `version-type` and runs `mvn release:prepare`
-  + `mvn release:perform`
+- Bumps the project version automatically based on `version-type` and runs `mvn release:prepare` + `mvn release:perform`
 - Supports **dry-run** mode: builds and deploys the current SNAPSHOT version without tagging or
   pushing any changes
 - Signs artifacts via GPG using `actions/setup-java` key import

--- a/actions/maven-snapshot-deploy/README.md
+++ b/actions/maven-snapshot-deploy/README.md
@@ -1,83 +1,121 @@
-# Maven Snapshot Deploy Action
+# 🚀 Maven Snapshot Deploy
 
-This GitHub Action builds and deploys a Maven project to either Maven Central or GitHub Packages. It checks if the version is a `SNAPSHOT` version and deploys accordingly. If the version is not a `SNAPSHOT`, it runs the `mvn install` command instead.
+Builds and deploys a Maven project to either Maven Central or GitHub Packages. Automatically
+detects whether the project version is a SNAPSHOT and deploys accordingly — if the version has
+no `-SNAPSHOT` suffix, the action falls back to `mvn install` instead of deploying.
 
-## Inputs
+---
 
-### `java-version`
+## Features
 
-**Optional**
-The JDK version to use. Defaults to `21`.
+- Detects SNAPSHOT versions in `pom.xml` using `xmlstarlet` — supports both direct
+  `<version>` and property-based `${revision}` patterns
+- Configures Maven authentication and GPG signing automatically for Central or GitHub Packages
+- Optionally pins a specific Maven version via `stCarolas/setup-maven`
+- Caches the local Maven repository (`~/.m2/repository`) to speed up subsequent runs
+- Auto-injects a `github` server entry into `~/.m2/settings.xml` when deploying to GitHub Packages
+- Activates a named Maven profile (`-P<target-store>`) when it exists in `pom.xml`
+- Supports non-root `pom.xml` paths and sub-directory working directories
+- Optionally uploads compiled output (`**/target`) as a GitHub Actions artifact
+- Surfaces key build decisions and version check results in the workflow step summary
 
-### `maven-version`
+---
 
-**Optional**
-The maven version to use. GitHub runner default maven will be used.
+## 📌 Inputs
 
-### `target-store`
+| Name | Description | Required | Default |
+| --- | --- | --- | --- |
+| `java-version` | JDK version to use (e.g. `21`). | No | `21` |
+| `maven-version` | Maven version to install. When empty, the runner's pre-installed Maven is used. | No | - |
+| `target-store` | Target registry for deployment. Use `central` for Maven Central or `github` for GitHub Packages. | No | `central` |
+| `maven-command` | Maven lifecycle command to execute. Defaults to `deploy` (SNAPSHOT versions) or `install` (non-SNAPSHOT). | No | `deploy` |
+| `additional-mvn-args` | Extra Maven command-line arguments appended to the final `mvn` invocation (e.g. `-Dskip.tests=true`). | No | - |
+| `working-directory` | Directory to run Maven commands from. Useful when the repository contains multiple independent `pom.xml` files. | No | - |
+| `pom-file` | Path to the `pom.xml` file, relative to `working-directory`. | No | `pom.xml` |
+| `upload-artifact` | Set to `true` to upload the `**/target` directory tree as a GitHub Actions artifact after the build. | No | `false` |
+| `artifact-id` | Name for the uploaded artifact. Applies only when `upload-artifact` is `true`. | No | `maven-snapshot-deploy-artifact` |
+| `maven-username` | Username for Maven registry authentication. | No | - |
+| `maven-token` | Token or password for Maven registry authentication. | Yes | - |
+| `gpg-private-key` | Armored GPG private key used to sign artifacts before deployment. | No | - |
+| `gpg-passphrase` | Passphrase for the GPG private key. | No | - |
+| `sonar-token` | SonarQube/SonarCloud token, passed as `SONAR_TOKEN` to the Maven process. | No | - |
 
-**Optional**
-The target store for the artifact. Can be `central` or `github`. Defaults to `central`.
+---
 
-### `maven-command`
+## How it works
 
-**Optional**
-Maven command to execute (default is 'deploy' for SNAPSHOT versions, 'install' otherwise).
+The action resolves the effective Maven command before running the build:
 
+1. **SNAPSHOT check** — when `maven-command` is `deploy`, the action reads `pom.xml` with
+   `xmlstarlet` to determine whether the project version (or `${revision}` property) ends in
+   `-SNAPSHOT`. If it does not, the command is automatically downgraded to `install` so no
+   artifact is published from a release-tagged build.
 
-### `additional-mvn-args`
+1. **Profile activation** — the action checks whether a Maven profile named after `target-store`
+   exists in `pom.xml`. When found, it adds `-P<target-store>` to the Maven invocation, enabling
+   repository-specific configuration (distribution management, plugins, etc.).
 
-**Optional**
-Additional Maven command-line parameters (e.g., `-Dskip.tests=true`). Defaults to an empty string.
+1. **JDK and credentials setup** — for `deploy` commands, `actions/setup-java` configures the
+   Maven `server-id` matching `target-store` and wires in `MAVEN_USERNAME` / `MAVEN_PASSWORD`
+   environment variables, plus GPG signing if keys are provided. For non-deploy commands, a plain
+   JDK is set up without credential injection.
 
-### `working-directory`
+1. **GitHub Packages server** — the action automatically adds a `github` server block to
+   `~/.m2/settings.xml` (using `GITHUB_ACTOR` and `GITHUB_TOKEN`) when it is not already present,
+   ensuring GitHub Packages dependencies and deployments always resolve correctly.
 
-**Optional**
-Working directory for the action. It is usefull when there are several independant pom.xml files in the repository.
-Default is `.`.
+1. **Maven execution** — the final command takes the form:
 
-### `pom-file`
+   ```text
+   mvn --batch-mode <command> [<-Pprofile>] [<additional-args>] [-f <pom-file>]
+   ```
 
-**Optional**
-Path and name of pom.xml file. Path to file must be relative to `working-directory`.
-Default is `pom.xml`
+1. **Artifact upload** — when `upload-artifact` is `true`, all `**/target` directories are
+   uploaded under the name given by `artifact-id`.
 
-### `upload-artifact`
+---
 
-**Optional**
-Upload `**/target` as an artifact to the workflow artifacts. Defaults to `'false'`.
+## Additional Information
 
-### `artifact-id`
+### `target-store` values
 
-**Optional**
-Artifact ID. Defaults to `maven-snapshot-deploy-artifact`.
+| Value | Registry |
+| --- | --- |
+| `central` | Maven Central (via Central Publishing Maven Plugin) |
+| `github` | GitHub Packages (uses `GITHUB_ACTOR` / `GITHUB_TOKEN`) |
 
-### `maven-username`
+The value must match a `<profile><id>` in your `pom.xml` for profile activation to take effect.
+See the [pom.xml configuration guide](https://github.com/Netcracker/.github/blob/main/docs/maven-publish-pom-preparation_doc.md)
+for the required structure.
 
-**Optional**
-The username for Maven authentication.
+### `maven-command` and SNAPSHOT detection
 
-### `maven-token`
+When `maven-command` is `deploy`:
 
-**Required**
-The token for Maven authentication.
+- The action parses `pom.xml` to find the effective version (direct `<version>` or
+  `<properties><revision>` when the version contains `${revision}`).
+- If the version does **not** contain `-SNAPSHOT`, the command is replaced with `install` and
+  nothing is deployed. This prevents accidentally publishing a release build as a snapshot.
 
-### `gpg-private-key`
+When `maven-command` is anything other than `deploy` (e.g. `clean verify`), the SNAPSHOT check
+is skipped and the command is passed through as-is.
 
-**Optional**
-The GPG private key for signing artifacts.
+### GPG signing
 
-### `gpg-passphrase`
+Provide `gpg-private-key` and `gpg-passphrase` to enable artifact signing. These are forwarded
+to `actions/setup-java`, which imports the key and configures Maven to use it automatically.
+For Netcracker repositories both secrets are available at org level as `MAVEN_GPG_PRIVATE_KEY`
+and `MAVEN_GPG_PASSPHRASE`.
 
-**Optional**
-The passphrase for the GPG private key.
+### `working-directory` and `pom-file`
 
-### `sonar-token`
+Use `working-directory` when your repository root is not the Maven project root. The `pom-file`
+path is relative to `working-directory`. The action validates that the file exists before
+proceeding and exits with an error if it is not found.
 
-**Optional**
-Sonar token. Default to `''`
+---
 
-## Example Usage
+## Usage
 
 ```yaml
 name: Deploy Snapshot
@@ -86,51 +124,56 @@ on:
   push:
     branches:
       - develop
-permissions:
-  packages: write # Required for GitHub packages deployment. For maven central deployment it can be omitted
-  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Code quality/security scan on SonarQube
-        uses: netcracker/qubership-workflow-hub/actions/maven-snapshot-deploy@main
+      - name: Code quality scan on SonarQube
+        uses: netcracker/qubership-workflow-hub/actions/maven-snapshot-deploy@v2.2.1
         with:
           java-version: '17'
           target-store: 'github'
           maven-command: 'clean verify'
-          additional-mvn-args: 'org.sonarsource.scanner.maven:sonar-maven-plugin:5.0.0.4389:sonar -Dsonar.projectKey=Netcracker_qubership -Dsonar.organization=netcracker -Dsonar.host.url=https://sonarcloud.io'
-          maven-username: ${{ github.actor }} # For maven central repository it would be ${{ secrets.MAVEN_USER }}. Already set for Netcracker.
-          maven-token: ${{ github.token }} # For maven central repository it would be ${{ secrets.MAVEN_PASSWORD}}. Already set for Netcracker.
-          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }} # Organization level secret. Already set for Netcracker.
-          gpg-passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }} # Organization level secret. Already set for Netcracker.
-          sonar-token: ${{ secrets.SONAR_TOKEN }} # Organization level secret. Already set for Netcracker.
+          additional-mvn-args: >-
+            org.sonarsource.scanner.maven:sonar-maven-plugin:5.0.0.4389:sonar
+            -Dsonar.projectKey=Netcracker_qubership
+            -Dsonar.organization=netcracker
+            -Dsonar.host.url=https://sonarcloud.io
+          maven-username: ${{ github.actor }}
+          maven-token: ${{ github.token }}
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          gpg-passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+          sonar-token: ${{ secrets.SONAR_TOKEN }}
 
       - name: Deploy Maven Snapshot
-        uses: netcracker/qubership-workflow-hub/actions/maven-snapshot-deploy@main
+        uses: netcracker/qubership-workflow-hub/actions/maven-snapshot-deploy@v2.2.1
         with:
           java-version: '17'
           target-store: 'github'
           maven-command: 'deploy'
           additional-mvn-args: '-Dskip.tests=true'
-          maven-username: ${{ github.actor }} # For maven central repository it would be ${{ secrets.MAVEN_USER }}. Already set for Netcracker.
-          maven-token: ${{ github.token }} # For maven central repository it would be ${{ secrets.MAVEN_PASSWORD}}. Already set for Netcracker.
-          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }} # Organization level secret. Already set for Netcracker.
-          gpg-passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }} # Organization level secret. Already set for Netcracker.
+          maven-username: ${{ github.actor }}
+          maven-token: ${{ github.token }}
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          gpg-passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
 ```
 
-## How It Works
-
-1. **Check Version**: The action checks if the version in `pom.xml` contains `-SNAPSHOT`. If it does, the artifact is deployed. Otherwise, the `mvn install` command is executed.
-2. **Setup JDK**: The specified JDK version is set up using `actions/setup-java`.
-3. **Deploy Artifacts**: The action deploys the artifact to the specified target store (`central` or `github`).
-4. **GPG Signing**: If a GPG private key and passphrase are provided, the artifacts are signed before deployment.
+---
 
 ## Notes
 
-- Ensure that the `pom.xml` file is correctly configured for deployment. [How to configure pom.xml](https://github.com/Netcracker/.github/blob/main/docs/maven-publish-pom-preparation_doc.md)
-- Secrets to use to publish to Maven Central can be found there [Organization level secrets](https://github.com/Netcracker/.github/blob/main/docs/maven-publish-secrets_doc.md)
-- For deploying to GitHub Packages, additional setup is performed to disable the `central-publishing-maven-plugin` and set an alternative deployment repository.
+- `packages: write` permission is required for GitHub Packages deployment; it can be omitted
+  for Maven Central deployments.
+- Ensure `pom.xml` contains a `<profile>` whose `<id>` matches `target-store` for profile
+  activation to work. See the
+  [pom.xml configuration guide](https://github.com/Netcracker/.github/blob/main/docs/maven-publish-pom-preparation_doc.md).
+- Organization-level secrets for Maven Central are documented in the
+  [secrets guide](https://github.com/Netcracker/.github/blob/main/docs/maven-publish-secrets_doc.md).
+- The `upload-artifact` input is a `string`, not a boolean — pass `'true'` (quoted) to enable it.
+- Always pin to `@v2.2.1` or a specific SHA — never `@main` in production.

--- a/docs/actions-workflows-catalog.md
+++ b/docs/actions-workflows-catalog.md
@@ -29,7 +29,7 @@ Always check that document before modifying or depending on a deprecated compone
 | [docker-config-resolver](../actions/docker-config-resolver/README.md)           | Load, validate, and normalize Docker component configuration |
 | [ghcr-discover-repo-packages](../actions/ghcr-discover-repo-packages/README.md) | Discover and list all GHCR packages for a repository         |
 | [k8s-hardening-scan](../actions/k8s-hardening-scan/README.md)                   | Validate container hardening compliance for Kubernetes deployments |
-| [maven-release](../actions/maven-release/README.md)                             | Run Maven release scripting (docs WIP)                       |
+| [maven-release](../actions/maven-release/README.md)                             | Build and release a Maven artifact with version bumping and GPG signing |
 | [maven-snapshot-deploy](../actions/maven-snapshot-deploy/README.md)             | Deploy Maven SNAPSHOT artifacts                              |
 | [metadata-action](../actions/metadata-action/README.md)                         | Produce version / tag metadata outputs                       |
 | [poetry-publisher](../actions/poetry-publisher/README.md)                       | Build, test & publish Poetry-based Python package            |


### PR DESCRIPTION
# Pull Request

## Summary

Rewrites the READMEs for two Maven actions — `maven-snapshot-deploy` and `maven-release` —
to match the project's standard documentation structure. Both previously used ad-hoc
heading-per-input formats, lacked Features and Additional Information sections, and contained
`@main` version pins. The updated READMEs introduce standard `📌 Inputs` / `📌 Outputs` tables,
caller-perspective `How it works` sections, and Additional Information subsections covering
non-obvious behaviours such as SNAPSHOT detection logic, dry-run string semantics,
cross-repository checkout via `module`, and Maven groupId policy validation.
The catalog entry for `maven-release` is updated to remove the stale "(docs WIP)" marker.

## Issue

No linked issue — documentation-only sync to bring both READMEs in line with current action
source and project documentation standards.

## Breaking Change?

- [ ] Yes
- [x] No

## Scope / Project

`actions/maven-snapshot-deploy`, `actions/maven-release`, `docs/actions-workflows-catalog.md`

## Implementation Notes

Documentation update only — no behaviour change to either action.

**maven-snapshot-deploy:**

- Converted 13 per-heading inputs to a standard `📌 Inputs` table (all 11 inputs from
  `action.yaml`, including `maven-command`, `working-directory`, `pom-file`, `upload-artifact`,
  `artifact-id`, and `sonar-token` which were present but poorly documented).
- Added `## Features` section listing SNAPSHOT detection, Maven cache, GPG signing, Maven version
  pinning, profile activation, `~/.m2/settings.xml` auto-injection, artifact upload, and step
  summary output.
- Rewrote `## How it works` as a caller-perspective description of what the action decides and
  produces — replacing the old step-narration list.
- Added `## Additional Information` with subsections: `target-store` values table, `maven-command`
  SNAPSHOT detection logic (including `${revision}` property handling), GPG signing, and
  `working-directory`/`pom-file` path relationship.
- Fixed `permissions` block placement: moved from workflow level to job level in the Usage example.
- Replaced `@main` pins with `@v2.2.1` in the Usage section.
- Added note that `upload-artifact` is a `string` input, not a boolean.

**maven-release:**

- Converted wide-column inputs table to standard format; clarified descriptions for `dry-run`
  (string equality, not boolean), `module` (cross-repo checkout constructs `<org>/<module>`),
  `maven-version` (empty means runner default), and `bump-dependencies-after-release` coupling
  with `dry-run`.
- Converted `## 📌 Outputs` from heading-per-output to standard table with example value.
- Rewrote `## How it works` to cover both dry-run and actual release paths from the caller's
  perspective, including `mvn versions:use-releases` → `release:prepare` → `release:perform`
  sequence and the optional post-release dependency bump.
- Added `## Additional Information` with subsections: version bumping computation table
  (patch/minor/major with example), `module` cross-repository checkout explanation, `dry-run`
  string-equality caveat, Maven groupId policy validation (previously undocumented step that
  blocks `org.qubership` and `com.netcracker` exact groupIds), GPG signing requirement rationale,
  and `bump-dependencies-after-release` hardcoded dependency filter.
- Updated Usage example: added `workflow_dispatch` inputs for `version-type` and `dry-run`,
  moved `permissions` to job level, replaced `@main` with `@v2.2.1`, corrected secret names
  (`MAVEN_GPG_PRIVATE_KEY` / `MAVEN_GPG_PASSPHRASE`).
- Added Notes warning that `secrets.GITHUB_TOKEN` does not have write access to other repos
  for cross-repository releases (PAT required).

**Catalog:**

- Updated `maven-release` description from "Run Maven release scripting (docs WIP)" to
  "Build and release a Maven artifact with version bumping and GPG signing".

## Tests / Evidence

Documentation-only change — no behaviour change. Verified manually:

- All fenced code blocks have language identifiers (`yaml`, `text`)
- All ordered list items use `1.` prefix (MD029 compliant)
- Blank lines before/after all headings, lists, and fenced blocks (MD022, MD031, MD032)
- No lines exceed 120 characters outside code blocks and tables (MD013)
- No `@main` pins remain in any Usage section

## Additional Notes

None.