### PR TITLE
chore: k8s-hardening-scan action changed default config path

### DIFF
--- a/actions/k8s-hardening-scan/README.md
+++ b/actions/k8s-hardening-scan/README.md
@@ -30,7 +30,7 @@ and uploads raw JSON results as workflow artifacts.
 | `execute-kubescape-scan`   | Run the Kubescape scan step                                                     | No       | `true`                          |
 | `execute-trivy-scan`       | Run the Trivy Helm chart misconfiguration scan (requires repository checkout)   | No       | `false`                         |
 | `fail-on-mandatory-checks` | Fail the job if any mandatory hardening checks did not pass                     | No       | `false`                         |
-| `config-file`              | Path to the caller's hardening config YAML (overrides mandatory flags per rule) | No       | `.github/hardening-config.yaml` |
+| `config-file`              | Path to the caller's hardening config YAML (overrides mandatory flags per rule) | No       | `.qubership/hardening-config.yaml` |
 
 ---
 
@@ -89,7 +89,7 @@ with `trivy config` for Helm chart misconfigurations, uploading results as a sep
 ### Hardening config file
 
 The action ships a built-in `hardening-config.yaml` that defines which rules are mandatory.
-The caller can provide a custom config at `config-file` (default: `.github/hardening-config.yaml`).
+The caller can provide a custom config at `config-file` (default: `.qubership/hardening-config.yaml`).
 The custom config supports an `ignored_checks` list that marks specific rule IDs as non-mandatory:
 
 ```yaml
@@ -157,7 +157,7 @@ jobs:
           execute-kubescape-scan: 'true'
           execute-trivy-scan: 'false'
           fail-on-mandatory-checks: 'false'
-          config-file: .github/hardening-config.yaml
+          config-file: .qubership/hardening-config.yaml
 ```
 
 ---

--- a/actions/k8s-hardening-scan/action.yaml
+++ b/actions/k8s-hardening-scan/action.yaml
@@ -20,7 +20,7 @@ inputs:
     default: false
   config-file:
     type: string
-    default: ".github/hardening-config.yaml"
+    default: ".qubership/hardening-config.yaml"
   report-title:
     type: string
     default: "Hardening Scan Report"

--- a/actions/k8s-hardening-scan/report-generator.py
+++ b/actions/k8s-hardening-scan/report-generator.py
@@ -233,8 +233,8 @@ def main():
     )
     parser.add_argument(
         '--config', '-c',
-        default='.github/hardening-config.yaml',
-        help='Path to the YAML configuration file (default: .github/hardening-config.yaml)'
+        default='.qubership/hardening-config.yaml',
+        help='Path to the YAML configuration file (default: .qubership/hardening-config.yaml)'
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
# Pull Request

## Summary

Changed default config path in k8s-hardening-scan action from `.github` to `.qubership`

## Issue
Link to the issue(s) this PR addresses (e.g., `Fixes #123` or `Closes #456`). If no issue exists, explain why this change is necessary.

## Breaking Change?
- [ ] Yes
- [X] No

## Scope / Project
`actions`
