### PR TITLE
feat(actions/k8s-hardening-scan): add per-image check ignore rules

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -8,7 +8,7 @@ MD013:
   # Number of characters
   line_length: 500
   # Number of characters for headings
-  heading_line_length: 80
+  heading_line_length: 100
   # Number of characters for code blocks
   code_block_line_length: 500
   # Include code blocks

--- a/actions/k8s-hardening-scan/README.md
+++ b/actions/k8s-hardening-scan/README.md
@@ -13,8 +13,9 @@ and uploads raw JSON results as workflow artifacts.
 - Generates a per-Deployment markdown table with pass/fail status for each control
 - Checks for critical exposed ports and containers using the `latest` image tag
 - Marks configurable rules as mandatory; writes `failed_mandatory_checks.json` when any fail
-- Appends the full markdown report to the GitHub Actions step summary
+- Appends the full markdown report (with collapsible summary) to the GitHub Actions step summary
 - Uploads Kubescape JSON results and (optionally) Trivy results as workflow artifacts
+- Supports per-image ignore rules to skip specific checks for specific container images
 - Optionally scans Helm chart misconfiguration with Trivy
 - Can gate the workflow — fails the job when mandatory checks are violated
 
@@ -22,15 +23,16 @@ and uploads raw JSON results as workflow artifacts.
 
 ## 📌 Inputs
 
-| Name                       | Description                                                                     | Required | Default                         |
-| -------------------------- | ------------------------------------------------------------------------------- | -------- | ------------------------------- |
-| `namespaces`               | Comma-separated list of Kubernetes namespaces to include in the scan            | No       | -                               |
-| `output-file`              | Base filename for JSON scan results (prefixed by tool name)                     | No       | `results.json`                  |
-| `install-kubescape`        | Install Kubescape before scanning. Set to `false` if already installed          | No       | `true`                          |
-| `execute-kubescape-scan`   | Run the Kubescape scan step                                                     | No       | `true`                          |
-| `execute-trivy-scan`       | Run the Trivy Helm chart misconfiguration scan (requires repository checkout)   | No       | `false`                         |
-| `fail-on-mandatory-checks` | Fail the job if any mandatory hardening checks did not pass                     | No       | `false`                         |
+| Name                       | Description                                                                     | Required | Default                            |
+| -------------------------- | ------------------------------------------------------------------------------- | -------- | ---------------------------------- |
+| `namespaces`               | Comma-separated list of Kubernetes namespaces to include in the scan            | No       | -                                  |
+| `output-file`              | Base filename for JSON scan results (prefixed by tool name)                     | No       | `results.json`                     |
+| `install-kubescape`        | Install Kubescape before scanning. Set to `false` if already installed          | No       | `true`                             |
+| `execute-kubescape-scan`   | Run the Kubescape scan step                                                     | No       | `true`                             |
+| `execute-trivy-scan`       | Run the Trivy Helm chart misconfiguration scan (requires repository checkout)   | No       | `false`                            |
+| `fail-on-mandatory-checks` | Fail the job if any mandatory hardening checks did not pass                     | No       | `false`                            |
 | `config-file`              | Path to the caller's hardening config YAML (overrides mandatory flags per rule) | No       | `.qubership/hardening-config.yaml` |
+| `report-title`             | Title shown at the top of the generated markdown report                         | No       | `Hardening Scan Report`            |
 
 ---
 
@@ -38,32 +40,51 @@ and uploads raw JSON results as workflow artifacts.
 
 This action produces no step outputs. Results are communicated through:
 
-| Output                          | Description                                                                                    |
-| ------------------------------- | ---------------------------------------------------------------------------------------------- |
-| GitHub Actions step summary     | Markdown report with a per-Deployment control table, appended to `$GITHUB_STEP_SUMMARY`       |
-| `kubescape-<output-file>`       | Workflow artifact containing the raw Kubescape JSON results                                    |
-| `trivy-<output-file>`           | Workflow artifact containing Trivy misconfiguration results (only when Trivy scan is enabled)  |
-| `failed_mandatory_checks.json`  | Written to the workspace when at least one mandatory check fails (used by gate step)           |
+| Output                         | Description                                                                                   |
+| ------------------------------ | --------------------------------------------------------------------------------------------- |
+| GitHub Actions step summary    | Markdown report with a per-Deployment control table, appended to `$GITHUB_STEP_SUMMARY`      |
+| `kubescape-<output-file>`      | Workflow artifact containing the raw Kubescape JSON results                                   |
+| `trivy-<output-file>`          | Workflow artifact containing Trivy misconfiguration results (only when Trivy scan is enabled) |
+| `failed_mandatory_checks.json` | Written to the workspace when at least one mandatory check fails (used by gate step)          |
 
 ---
 
 ## How it works
 
-The action scans live Kubernetes Deployments and produces a per-resource markdown report.
-For each Deployment found in the scanned namespaces the report contains a control table:
+The action scans live Kubernetes Deployments and produces a collapsible per-resource markdown report.
+For each Deployment found in the scanned namespaces the report contains a control table under a
+`<details>` summary block:
 
 ```text
+### Hardening Scan Report
+<details>
+<summary>Summary</summary>
+
+## Summary by resources
+
+- `default/Deployment/my-app`: ✅ 5 / ❌ 1
+  - registry.example.com/my-app:1.0.0
+
+---
+
 ## Resource: `default/Deployment/my-app`
 
-| ControlID        | Control name              | Status |
-|------------------|---------------------------|--------|
-| C-0013           | Non-root containers       | ✅     |
-| C-0016           | Allow privilege escalation| ❌     |
-| Critical-Ports   | Critical Ports            | ✅     |
-| Latest-Tag       | No images using 'latest'  | ✅     |
+### Resource Images:
 
-**Total:** ✅ passed: 3, ❌ failed: 1
+- registry.example.com/my-app:1.0.0
+
+| ControlID      | Control name                          | Status |
+|----------------|---------------------------------------|--------|
+| C-0013         | Non-root containers (Mandatory)       | ✅     |
+| C-0016         | Allow privilege escalation (Mandatory)| ❌     |
+| Critical-Ports | Critical Ports                        | ✅     |
+| Latest-Tag     | No images using 'latest' tag          | ✅     |
+
+**Total:** ✅ passed: 5, ❌ failed: 1
+
 **Failed mandatory checks:** C-0016
+
+</details>
 ```
 
 When mandatory checks fail, the action writes `failed_mandatory_checks.json` to the workspace:
@@ -80,7 +101,7 @@ gating the workflow. The full report is always appended to the GitHub Actions st
 regardless of pass/fail outcome.
 
 When `execute-trivy-scan` is `true`, the action also checks out the repository and scans it
-with `trivy config` for Helm chart misconfigurations, uploading results as a separate artifact.
+with `trivy k8s` for cluster misconfigurations, uploading results as a separate zipped artifact.
 
 ---
 
@@ -90,45 +111,65 @@ with `trivy config` for Helm chart misconfigurations, uploading results as a sep
 
 The action ships a built-in `hardening-config.yaml` that defines which rules are mandatory.
 The caller can provide a custom config at `config-file` (default: `.qubership/hardening-config.yaml`).
-The custom config supports an `ignored_checks` list that marks specific rule IDs as non-mandatory:
+
+The custom config supports two sections:
+
+**`global_ignored_checks`** — marks specific rule IDs as non-mandatory for all resources:
 
 ```yaml
-ignored_checks:
+global_ignored_checks:
   - C-0048
   - Critical-Ports
 ```
 
-Any rule ID listed under `ignored_checks` will have its `mandatory` flag set to `false` for the
-run, suppressing failures for that check even when `fail-on-mandatory-checks` is `true`.
+**`image_ignored_checks`** — skips specific checks only for resources running a named image:
+
+```yaml
+image_ignored_checks:
+  registry.example.com/my-app:
+    - C-0016
+  legacy-app:
+    - C-0017
+    - C-0055
+```
+
+Any rule ID listed under `global_ignored_checks` has its `mandatory` flag set to `false` for
+the entire run. Rules listed under `image_ignored_checks` are suppressed only for resources
+whose image list matches the given image name.
 
 ### Built-in mandatory rules
 
 The following rules are mandatory by default (defined in the bundled `hardening-config.yaml`):
 
-| Rule ID          | Name                                                                             |
-| ---------------- | -------------------------------------------------------------------------------- |
-| `C-0013`         | Non-root containers                                                              |
-| `C-0016`         | Allow privilege escalation                                                       |
-| `C-0017`         | Immutable container filesystem                                                   |
-| `C-0055`         | Linux hardening                                                                  |
-| `C-0041`         | HostNetwork access                                                               |
-| `C-0045`         | Writable hostPath mount                                                          |
-| `C-0048`         | HostPath mount                                                                   |
-| `Critical-Ports` | Critical ports (22, 23, 25, 53, 67–69, 110, 143, 161, 162, 389, 636, 993, 995) |
-| `No-Latest-Tag`  | No `latest` image tag                                                            |
+| Rule ID          | Name                                                                              |
+| ---------------- | --------------------------------------------------------------------------------- |
+| `C-0013`         | Non-root containers                                                               |
+| `C-0016`         | Allow privilege escalation                                                        |
+| `C-0017`         | Immutable container filesystem                                                    |
+| `C-0055`         | Linux hardening                                                                   |
+| `C-0041`         | HostNetwork access                                                                |
+| `C-0045`         | Writable hostPath mount                                                           |
+| `C-0048`         | HostPath mount                                                                    |
+| `Critical-Ports` | Critical ports (22, 23, 25, 53, 67–69, 110, 143, 161, 162, 389, 636, 993, 995)  |
+| `No-Latest-Tag`  | No `latest` image tag                                                             |
 
 ### Trivy scan scope
 
-When `execute-trivy-scan` is `true`, the action checks out the repository and scans the entire
-repository root with `trivy config`. This detects misconfigurations in Helm chart templates and
-Kubernetes manifests committed to the repository. It does **not** scan running cluster workloads —
-that is the role of the Kubescape step.
+When `execute-trivy-scan` is `true`, the action checks out the repository into `temp/repocode`
+and runs `trivy k8s` against the cluster with `--include-namespaces`. This detects
+misconfigurations in live cluster workloads from Trivy's perspective. Results are uploaded as
+a zipped artifact named `trivy-<output-file>`.
 
 ### Namespace targeting
 
 The `namespaces` input is passed directly to `--include-namespaces`. Supply a single namespace
 or a comma-separated list (e.g. `default,kube-system`). Omitting this input causes Kubescape to
 scan all accessible namespaces.
+
+### Resources without images
+
+Resources that have no container images detected are skipped silently in the report. Only
+resources with at least one identifiable image appear in the per-resource control tables.
 
 ---
 
@@ -149,7 +190,7 @@ jobs:
       contents: read
     steps:
       - name: Run Kubernetes Hardening Scan
-        uses: netcracker/qubership-workflow-hub/actions/k8s-hardening-scan@v2.2.0
+        uses: netcracker/qubership-workflow-hub/actions/k8s-hardening-scan@v2.2.2
         with:
           namespaces: default
           output-file: results.json
@@ -158,6 +199,7 @@ jobs:
           execute-trivy-scan: 'false'
           fail-on-mandatory-checks: 'false'
           config-file: .qubership/hardening-config.yaml
+          report-title: Hardening Scan Report
 ```
 
 ---
@@ -174,4 +216,4 @@ jobs:
   conflict with other steps.
 - All boolean inputs (`install-kubescape`, `execute-kubescape-scan`, `execute-trivy-scan`,
   `fail-on-mandatory-checks`) must be passed as strings (`'true'` / `'false'`), not YAML booleans.
-- Always pin to `@v2.2.0` or a specific SHA — never `@main` in production.
+- Always pin to `@v2.2.2` or a specific SHA — never `@main` in production.

--- a/actions/k8s-hardening-scan/README.md
+++ b/actions/k8s-hardening-scan/README.md
@@ -114,7 +114,7 @@ The caller can provide a custom config at `config-file` (default: `.qubership/ha
 
 The custom config supports two sections:
 
-**`global_ignored_checks`** — marks specific rule IDs as non-mandatory for all resources:
+#### `global_ignored_checks` — marks specific rule IDs as non-mandatory for all resources
 
 ```yaml
 global_ignored_checks:
@@ -122,7 +122,7 @@ global_ignored_checks:
   - Critical-Ports
 ```
 
-**`image_ignored_checks`** — skips specific checks only for resources running a named image:
+#### `image_ignored_checks` — skips specific checks only for resources running a named image
 
 ```yaml
 image_ignored_checks:

--- a/actions/k8s-hardening-scan/report-generator.py
+++ b/actions/k8s-hardening-scan/report-generator.py
@@ -29,9 +29,12 @@ def load_yaml_config(config_path):
     config_data = {}
     # Try to load user config file
     # user config structure:
-    # ignored_checks:
+    # global_ignored_checks:
     #   - ControlID1
     #   - ControlID2
+    # image_ignored_checks:
+    #   image_name:
+    #     - ControlID1
     if not Path(config_path).is_file():
         print(f"⚠️  Warning: Config file '{config_path}' not found. Using default config path '{default_config_path}'.")
     else:
@@ -39,10 +42,17 @@ def load_yaml_config(config_path):
             config_data = yaml.safe_load(f)
     with open(default_config_path, 'r', encoding='utf-8') as f:
         default_config_data = yaml.safe_load(f)
-    # Merge default config with user config. Setting `mandatory` field to False for checks listed in `ignored_checks` in user config.
-    for check in config_data.get('ignored_checks', []):
+    # Merge default config with user config. Setting `mandatory` field to False for checks listed in `global_ignored_checks` in user config.
+    for check in config_data.get('global_ignored_checks', []):
         if check in default_config_data.get('hardening_rules', {}):
             default_config_data['hardening_rules'][check]['mandatory'] = False
+    individual_ignored_checks = config_data.get('image_ignored_checks', {})
+    for image, checks in individual_ignored_checks.items():
+        for check in checks:
+            if check in default_config_data.get('hardening_rules', {}):
+                if 'ignored_for_images' not in default_config_data['hardening_rules'][check]:
+                    default_config_data['hardening_rules'][check]['ignored_for_images'] = []
+                default_config_data['hardening_rules'][check]['ignored_for_images'].append(image)
     print(f"[DEBUG]: {default_config_data}")
     return default_config_data
 
@@ -110,12 +120,15 @@ def generate_markdown_tables(data, config):
     failed_mandatory_checks_all = {}
     output_lines = []
     for resource in results:
+        resource_mandatory_checks = mandatory_checks.copy()
         resource_id = resource.get('resourceID', 'Unknown')
         resource_data = next((r for r in resources if r.get('resourceID') == resource_id), {})
         resource_ports = get_resource_ports(resource_data)
         resource_images = get_resource_images(resource_data)
         if len(resource_images) == 0:
             continue
+        # need to strip the tag from the image name to compare with the ignored images in the config file, as the config file may contain image names without tags.
+        resource_images_stripped = [img.split(':')[0] for img in resource_images]
         controls = resource.get('controls', [])
         failed_mandatory_checks = []
 
@@ -131,7 +144,12 @@ def generate_markdown_tables(data, config):
             control_id = control.get('controlID', '')
             control_name = control.get('name', '')
             if control_id in mandatory_checks:
-                control_name += " (⚠️  Mandatory)"
+                if 'ignored_for_images' in config.get('hardening_rules', {}).get(control_id, {}) and any(img in config['hardening_rules'][control_id]['ignored_for_images'] for img in resource_images_stripped):
+                    print(f"⚠️  Skipping mandatory check '{control_id}' for resource '{resource_id}' due to image-based ignore rule.")
+                    resource_mandatory_checks.remove(control_id)
+                else:
+                    print(f"[DEBUG] Control '{control_id}' is mandatory for resource '{resource_id}'.")
+                    control_name += " (Mandatory)"
             rules = control.get('rules', [])
 
             # Each rule in a separate line.
@@ -140,14 +158,14 @@ def generate_markdown_tables(data, config):
                     status = rule.get('status', '')
                     status_emoji = get_status_emoji(status)
                     output_lines.append(f"| {control_id} | {control_name} ({rule.get('name', '')}) | {status_emoji} |")
-                    if control_id in mandatory_checks and status != 'passed' and control_id not in failed_mandatory_checks:
+                    if control_id in resource_mandatory_checks and status != 'passed' and control_id not in failed_mandatory_checks:
                         failed_mandatory_checks.append(control_id)
             else:
                 # Normal case - single rule
                 status = rules[0].get('status', '') if rules else control.get('status', {}).get('status', '')
                 status_emoji = get_status_emoji(status)
                 output_lines.append(f"| {control_id} | {control_name} | {status_emoji} |")
-                if control_id in mandatory_checks and status != 'passed':
+                if control_id in resource_mandatory_checks and status != 'passed':
                     failed_mandatory_checks.append(control_id)
 
         # compare resource ports with prohibited ports list from config file and add a line to the table if there is a match.
@@ -155,7 +173,7 @@ def generate_markdown_tables(data, config):
         ports_intersection = list(set(config.get('hardening_rules', {}).get('Critical-Ports', {}).get('critical_ports', [])) & set(resource_ports))
         if ports_intersection:
             output_lines.append(f"| Critical-Ports | Critical Ports: {', '.join(map(str, sorted(ports_intersection)))} | ❌ |")
-            if 'Critical-Ports' in mandatory_checks:
+            if 'Critical-Ports' in resource_mandatory_checks:
                 failed_mandatory_checks.append('Critical-Ports')
         else:
             output_lines.append("| Critical-Ports | Critical Ports | ✅ |")
@@ -165,7 +183,7 @@ def generate_markdown_tables(data, config):
         latest_images = [img for img in resource_images if img.endswith(':latest')]
         if latest_images:
             output_lines.append(f"| Latest-Tag | Images using 'latest' tag: {', '.join(latest_images)} | ❌ |")
-            if 'No-Latest-Tag' in mandatory_checks:
+            if 'No-Latest-Tag' in resource_mandatory_checks:
                 failed_mandatory_checks.append('No-Latest-Tag')
         else:
             output_lines.append("| Latest-Tag | No images using 'latest' tag | ✅ |")

--- a/actions/k8s-hardening-scan/report-generator.py
+++ b/actions/k8s-hardening-scan/report-generator.py
@@ -149,7 +149,8 @@ def generate_markdown_tables(data, config):
                     resource_mandatory_checks.remove(control_id)
                 else:
                     print(f"[DEBUG] Control '{control_id}' is mandatory for resource '{resource_id}'.")
-                    control_name += " (Mandatory)"
+                    # adding (Mandatory) bold label to the control name in the table for better visibility
+                    control_name += " **(Mandatory)**"
             rules = control.get('rules', [])
 
             # Each rule in a separate line.


### PR DESCRIPTION
# Pull Request

## Summary

Extends `k8s-hardening-scan` to support per-image ignore rules in the hardening config, allowing
callers to suppress specific Kubescape/custom checks only for resources running a named container
image. The `report-generator.py` now reads a new `image_ignored_checks` config section and builds
a per-resource effective mandatory-check set, so a check skipped for one image does not affect
other resources. The existing global ignore mechanism is also renamed from `ignored_checks` to
`global_ignored_checks` for clarity.

## Issue

Closes #762

## Breaking Change?

- [ ] Yes
- [x] No

## Scope / Project

`actions/k8s-hardening-scan`

## Implementation Notes

- Added `image_ignored_checks` section to the config YAML schema. Keys are image name prefixes
  (without tag); values are lists of control IDs to suppress for any resource whose image list
  contains a matching prefix (tag is stripped before comparison).
- Per-resource mandatory-check set (`resource_mandatory_checks`) is now derived by copying the
  global `mandatory_checks` set and then removing any control IDs whose `ignored_for_images` list
  intersects with the resource's images. This keeps the global set immutable across resources.
- The `ignored_for_images` field is added dynamically to each rule entry in
  `default_config_data['hardening_rules']` during config merge — no schema change to the
  built-in `hardening-config.yaml` is needed.
- Tag stripping (`img.split(':')[0]`) is intentional: the config is expected to list image names
  without tags so that ignore rules survive image upgrades without config edits.
- All four mandatory-check failure paths (`controls loop`, `Critical-Ports`, `No-Latest-Tag`,
  multi-rule controls) were updated to reference `resource_mandatory_checks` instead of the
  global `mandatory_checks`.
- README updated to document `image_ignored_checks`, the renamed `global_ignored_checks` key,
  the new `report-title` input, collapsible summary output format, and the corrected Trivy scan
  description (`trivy k8s` against cluster, not `trivy config` against repo).

## Tests / Evidence

No automated tests exist for `report-generator.py` (pure Python script, no test harness in this
action). Manual validation approach:

- Reviewed the per-resource mandatory-check copy logic to confirm the global set is not mutated
  between resources.
- Traced the tag-strip path: `registry.example.com/my-app:1.0.0`.split(':')[0]` →
  `registry.example.com/my-app`, which matches a config key of `registry.example.com/my-app`.
- Confirmed that resources with no images continue to be skipped before the ignore logic runs.

## Additional Notes

- Follow-up: consider adding a test fixture and pytest suite for `report-generator.py` to catch
  regressions in future config-schema changes.
- Callers must migrate `ignored_checks:` → `global_ignored_checks:` in their config files before
  deploying this version; no automatic fallback is provided.