### PR TITLE
ci(.github/workflows): replace deprecated commit-and-push action with inline git steps

### DIFF
--- a/.github/workflows/re-npm-publish.yml
+++ b/.github/workflows/re-npm-publish.yml
@@ -51,7 +51,6 @@ jobs:
     permissions:
       contents: write
       packages: write
-      id-token: write
     runs-on: ubuntu-latest
     env:
       NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/re-npm-publish.yml
+++ b/.github/workflows/re-npm-publish.yml
@@ -36,6 +36,12 @@ on:
         required: false
         type: string
         default: "main"
+      gh_app_id:
+        required: false
+        type: string
+    secrets:
+      GH_APP_KEY:
+        required: false
 
 env:
   VERSION: ${{ inputs.version }}
@@ -51,15 +57,24 @@ jobs:
       NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
+      - name: "Prepare app token"
+        if: ${{ inputs.gh_app_id }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ inputs.gh_app_id }}
+          private-key: ${{ secrets.GH_APP_KEY }}
+
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.ref}}
           fetch-depth: 0
           persist-credentials: false
+          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
           registry-url: ${{ inputs.registry-url }}
@@ -132,11 +147,17 @@ jobs:
           git diff --color
           git diff >> changes.txt
 
-      - name: Commit Changes
+      - name: Update Source on GitHub
         if: ${{ !inputs.dry-run }}
-        uses: netcracker/qubership-workflow-hub/actions/commit-and-push@7860be3b17e788ba26efe4ec4d699b4e786245b5 #v1.0.7
-        with:
-          commit_message: "Update package.json version to $VERSION"
+        env:
+          VERSION: ${{ env.VERSION }}
+          REF: ${{ inputs.ref }}
+        run: |
+          git config --global user.email "qubership-actions[bot]@users.noreply.github.com"
+          git config --global user.name "qubership-actions[bot]"
+          git add .
+          git commit -m "chore: update package.json version to ${VERSION}"
+          git push -u origin ${REF}
 
       - name: Get package version
         if: ${{ !inputs.dry-run }}


### PR DESCRIPTION
# Pull Request

## Summary
Replaces the deprecated `commit-and-push` composite action with an inline `run:` step
that configures git identity and pushes directly, consistent with how `python-publish.yml`
handles the same task. Also adds optional GitHub App token support (`gh_app_id` input +
`GH_APP_KEY` secret) to allow bypassing branch protection rules, and pins `actions/checkout`
and `actions/setup-node` to full SHA hashes.

## Issue
No linked issue.

## Breaking Change?
- [ ] Yes
- [x] No

## Scope / Project
`.github/workflows`

## Implementation Notes
- The `commit-and-push` action was pinned to a SHA that is incompatible with GitHub App
  token auth; inline git steps give full control over auth and commit identity.
- Bot identity (`qubership-actions[bot]@users.noreply.github.com`) matches the pattern
  used in `python-publish.yml`.
- `gh_app_id` / `GH_APP_KEY` are both optional — callers without a GitHub App continue
  to use `GITHUB_TOKEN` via the `||` fallback in the `token:` field.
- Removed unused `id-token: write` permission (no OIDC exchange occurs in this workflow).
- Pinned `actions/checkout` to `de0fac2e` (v6.0.2) and `actions/setup-node` to
  `48b55a01` (v6.4.0).

## Tests / Evidence
Workflow logic is unchanged for callers that don't pass `gh_app_id`; the only runtime
difference is the git commit step runs shell instead of a composite action.

## Additional Notes
None.