### PR TITLE
feat(actions/maven-monorepo-release): add Maven monorepo release action

### DIFF
--- a/.claude/skills/markdown-rules/SKILL.md
+++ b/.claude/skills/markdown-rules/SKILL.md
@@ -18,7 +18,7 @@ When invoked via `/md-lint [files]`, audit and fix target files directly.
   "MD007": { "indent": 2 },
   "MD013": { "line_length": 120, "code_blocks": false, "tables": false },
   "MD024": { "siblings_only": true },
-  "MD029": { "style": "one" },
+  "MD029": { "style": "ordered" },
   "MD033": { "allowed_elements": ["img", "br", "a", "p"] },
   "MD041": false,
   "MD046": { "style": "fenced" }
@@ -50,7 +50,7 @@ When invoked via `/md-lint [files]`, audit and fix target files directly.
 | MD025 | More than one `#` heading in file | Demote extras to `##` |
 | MD026 | Heading ends with `.`, `,`, `;`, `!`, `?`, `:` | Remove trailing punctuation |
 | MD027 | Multiple spaces after `>` in blockquote | Reduce to one space |
-| MD029 | Ordered list item prefix ≠ `1.` | Replace all prefixes with `1.` |
+| MD029 | Ordered list item numbers are not sequential (e.g. `1, 3, 4` or gap after code block) | Renumber sequentially: `1. 2. 3.` — never skip, never repeat |
 | MD030 | More than one space after list marker | Normalise to one space |
 | MD031 | No blank line before/after fenced code block | Insert missing blank lines |
 | MD032 | List not surrounded by blank lines | Insert blank lines before first and after last item |
@@ -82,8 +82,12 @@ When invoked via `/md-lint [files]`, audit and fix target files directly.
 Tilde fences (`~~~`) are also prohibited (MD048). Solution: close the outer block, show the
 inner example as a standalone fenced block in a separate paragraph.
 
-**MD029 + code fences in lists** — a code fence between list items resets the counter.
-For lists that contain embedded code blocks, use bullet points (`-`) instead of numbered lists.
+**MD029 + code fences in lists** — a fenced code block inside a list item (indented 3+ spaces)
+continues the list without resetting the counter, provided the fence is indented under the item.
+An unindented fence breaks the list and resets the counter — the next item must start from `1.`
+again. When auditing: scan the whole list, detect any counter gaps or resets, and renumber the
+entire sequence `1. 2. 3. …` end-to-end. If a gap is caused by a misplaced unindented fence,
+either indent the fence under its list item or convert the list to bullet points (`-`).
 
 **MD040 language identifiers** — use `text` for plain text, directory trees, or any content
 that has no specific language. Never leave the opening fence bare.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ duplicate pipeline scripts.
 ## Repository structure
 
 ```text
-actions/          — 23 individual GitHub Actions (each self-contained)
+actions/          — 24 individual GitHub Actions (each self-contained)
 packages/         — Shared internal packages used by Node.js actions
   action-logger/  — Lightweight colored logger (@qubership/action-logger)
 .github/

--- a/actions/maven-monorepo-release/README.md
+++ b/actions/maven-monorepo-release/README.md
@@ -1,0 +1,392 @@
+# 🚀 Maven Monorepo Release Action
+
+Automates releasing individual Maven components from a monorepo with **independent versioning per component**. Handles version bumping (major/minor/patch or explicit version), GPG signing, publishing to Maven Central or GitHub Packages, and automatic dependency updates within the monorepo.
+
+**Key difference from `maven-release`**: This action does NOT use Maven Release Plugin (which is incompatible with monorepos). Instead, it implements custom version management that handles:
+- Independent component versioning
+- Automatic dependency updates between monorepo components
+- GitHub releases with component-scoped tags (`component-name-version`)
+- Parent POM version synchronization
+- Dry-run validation
+
+---
+
+## Features
+
+### Version Management
+- **Independent versioning**: Each component maintains its own version independent of others
+- **Flexible bumping**: Support for `major`, `minor`, `patch`, or explicit semantic versions (e.g., `1.2.3`)
+- **SNAPSHOT handling**: Automatically manages `-SNAPSHOT` versions between releases
+
+### Publishing
+- **Dual targets**: Publish to Maven Central, GitHub Packages, or both
+- **GPG signing**: Optional GPG signing for Maven Central compliance
+- **GitHub releases**: Creates annotated git tags in format `<component>-<version>`
+
+### Dependency Management
+- **Inter-module updates**: Automatically updates component versions in dependent modules within monorepo
+- **Parent versioning**: Option to update parent POM references in child modules
+- **BOM management**: Full support for BOM (Bill of Materials) modules
+
+### Safety & Validation
+- **Dry-run mode**: Build and validate without creating tags, commits, or pushing
+- **Structure validation**: Ensures monorepo structure is correct before release
+- **Build verification**: Validates component builds successfully before releasing
+
+---
+
+## 📌 Inputs
+
+| Name | Description | Required | Default |
+| --- | --- | --- | --- |
+| `component` | Component to release: `parent`, `bom`, or folder name (e.g., `my-component`) | Yes | - |
+| `version-type` | Bump type: `major`, `minor`, `patch`, or explicit version like `1.2.3` | Yes | `patch` |
+| `ref` | Branch to release from | No | `main` |
+| `publish-target` | Where to publish: `maven-central`, `github`, or `both` | No | `github` |
+| `java-version` | Java version (LTS: 21, 17, 11) | No | `21` |
+| `maven-version` | Maven version to use. Empty = use runner's pre-installed Maven | No | - |
+| `maven-args` | Additional Maven arguments for all invocations | No | `-DskipTests=true -Dmaven.javadoc.skip=true -B` |
+| `dry-run` | Set to `'false'` to perform actual release. `'true'` = validation only | No | `'true'` |
+| `token` | GitHub token for checkout and git operations | Yes | - |
+| `gpg-private-key` | Armored GPG private key (required for Maven Central) | No | - |
+| `gpg-passphrase` | GPG passphrase | No | - |
+| `maven-central-username` | Sonatype username (required for Maven Central) | No | - |
+| `maven-central-password` | Sonatype password or token (required for Maven Central) | No | - |
+| `maven-profile` | Maven profile to activate (e.g., `release`) | No | - |
+| `update-parent-version` | Set to `'true'` to update parent version in child modules after parent release | No | `'false'` |
+
+---
+
+## 📌 Outputs
+
+| Name | Description |
+| --- | --- |
+| `release-version` | Released version (e.g., `2.1.0`) |
+| `component-released` | Name of component released |
+| `artifacts` | Published artifact coordinates (groupId:artifactId:version) |
+
+---
+
+## Monorepo Structure
+
+This action expects a Maven monorepo structured like:
+
+```
+monorepo-root/
+├── pom.xml                    # Root aggregator POM (optional, lists modules)
+├── parent/
+│   └── pom.xml               # Parent POM
+├── bom/
+│   └── pom.xml               # BOM (Bill of Materials) provides dependencyManagement
+├── my-component-1/
+│   ├── pom.xml               # References <parent>
+│   ├── src/
+│   └── ...
+├── my-component-2/
+│   ├── pom.xml               # References <parent>, may depend on my-component-1
+│   ├── src/
+│   └── ...
+└── ...
+```
+
+### Key requirements:
+
+1. **Root directory**: Each component lives in its own top-level folder (e.g., `parent`, `bom`, `my-component`)
+2. **Parent POM**: All non-parent components should inherit from `parent/pom.xml` via `<parent>` element
+3. **Independent versions**: Each component's `pom.xml` declares its own `<version>` (not inherited from parent)
+4. **Inter-dependencies**: Components can depend on other components within the monorepo
+
+---
+
+## Release Workflow
+
+### Dry-run mode (default, `dry-run: 'true'`)
+
+1. Validates monorepo structure
+2. Builds component (runs `mvn clean package`)
+3. **Does NOT**: bump version, commit, tag, or push
+4. Useful for validation before committing to a release
+
+### Release mode (`dry-run: 'false'`)
+
+1. **Get current version** from component's `pom.xml`
+2. **Bump version** based on `version-type` (major/minor/patch)
+3. **Update pom.xml** with release version
+4. **Build component** (`mvn clean package`)
+5. **Deploy** to Maven Central and/or GitHub Packages
+6. **Commit** release version change and push
+7. **Create git tag** in format `<component>-<version>` (e.g., `my-component-2.1.0`)
+8. **Update to next SNAPSHOT** version (e.g., `2.1.1-SNAPSHOT`)
+9. **Update dependencies** in other monorepo components (if configured)
+10. **Update parent version** in child modules (if component is parent and flag enabled)
+
+---
+
+## Usage Examples
+
+### Example 1: Release a component to GitHub Packages (dry-run)
+
+```yaml
+name: Release Component (Dry-Run)
+
+on:
+  workflow_dispatch:
+    inputs:
+      component:
+        description: 'Component to release'
+        required: true
+      version-type:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        options: [major, minor, patch]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Release (Dry-Run)
+        uses: netcracker/qubership-workflow-hub/actions/maven-monorepo-release@v1.0.0
+        with:
+          component: ${{ inputs.component }}
+          version-type: ${{ inputs.version-type }}
+          dry-run: 'true'
+          token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Example 2: Actual release to Maven Central
+
+```yaml
+name: Release to Maven Central
+
+on:
+  workflow_dispatch:
+    inputs:
+      component:
+        description: 'Component to release'
+        required: true
+      version:
+        description: 'Version (major, minor, patch, or explicit like 1.2.3)'
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Release to Maven Central
+        uses: netcracker/qubership-workflow-hub/actions/maven-monorepo-release@v1.0.0
+        with:
+          component: ${{ inputs.component }}
+          version-type: ${{ inputs.version }}
+          publish-target: central
+          dry-run: 'false'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          gpg-passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+          maven-central-username: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          maven-central-password: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+```
+
+### Example 3: Release with dependency updates
+
+```yaml
+- name: Release Parent and Update Children
+  uses: netcracker/qubership-workflow-hub/actions/maven-monorepo-release@v1.0.0
+  with:
+    component: parent
+    version-type: minor
+    publish-target: centarl
+    dry-run: 'false'
+    update-parent-version: 'true'
+    token: ${{ secrets.GITHUB_TOKEN }}
+    gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+    gpg-passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+    maven-central-username: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+    maven-central-password: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+```
+
+---
+
+## Version Bumping Logic
+
+Given current version `2.1.3-SNAPSHOT`:
+
+| `version-type` | Result |
+| --- | --- |
+| `patch` | `2.1.4` |
+| `minor` | `2.2.0` |
+| `major` | `3.0.0` |
+| `1.2.3` (explicit) | `1.2.3` |
+
+After release, automatically bumped to next SNAPSHOT (e.g., `2.1.4-SNAPSHOT`).
+
+---
+
+## Dependency Management
+
+### Inter-module dependency updates
+
+When releasing a component that is a dependency for other components in the monorepo:
+
+1. Action scans all other `pom.xml` files for references to released component
+2. Automatically updates versions in dependent modules
+3. Commits changes with message: `chore(dependent-module): update component-name to X.Y.Z`
+
+**Example**: Releasing `my-lib:2.1.0` automatically updates `my-app` if it depends on `my-lib`.
+
+### Parent version updates
+
+When releasing parent with `update-parent-version: 'true'`:
+
+1. Action finds all modules with `<parent>` reference to released parent
+2. Updates their parent version to the released version
+3. Commits changes in each child module
+
+---
+
+## Git Tags and Releases
+
+Tags are created in format: `<component-name>-<version>`
+
+Examples:
+- `my-lib-1.0.0`
+- `my-app-2.1.3`
+- `parent-1.5.0`
+- `bom-3.0.0`
+
+Each tag points to the commit that updated the pom.xml to the release version.
+
+---
+
+## Configuration Requirements
+
+### pom.xml Structure
+
+Each component must have:
+
+```xml
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>my-component</artifactId>
+  <version>1.0.0</version>  <!-- Must be present and independently versioned -->
+
+  <!-- For non-parent components, inherit from parent -->
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0.0</version>
+  </parent>
+
+  <!-- Dependencies are OK and will be auto-updated -->
+  <dependencies>
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>my-lib</artifactId>
+      <version>1.0.0</version>
+    </dependency>
+  </dependencies>
+</project>
+```
+
+### settings.xml for Maven Central
+
+For Maven Central publishing, configure `~/.m2/settings.xml`:
+
+```xml
+<settings>
+  <servers>
+    <server>
+      <id>maven-central</id>
+      <username>${env.MAVEN_CENTRAL_USERNAME}</username>
+      <password>${env.MAVEN_CENTRAL_PASSWORD}</password>
+    </server>
+    <server>
+      <id>github</id>
+      <username>oauth2</username>
+      <password>${env.GITHUB_TOKEN}</password>
+    </server>
+  </servers>
+
+  <profiles>
+    <profile>
+      <id>release</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <properties>
+        <gpg.executable>gpg</gpg.executable>
+        <gpg.passphrase>${env.MAVEN_GPG_PASSPHRASE}</gpg.passphrase>
+      </properties>
+    </profile>
+  </profiles>
+</settings>
+```
+
+### GitHub Packages publishing
+
+Add to parent `pom.xml`:
+
+```xml
+<distributionManagement>
+  <repository>
+    <id>github</id>
+    <name>GitHub Packages</name>
+    <url>https://maven.pkg.github.com/YOUR-ORG/YOUR-REPO</url>
+  </repository>
+</distributionManagement>
+```
+
+---
+
+## Secrets Required
+
+### For Maven Central
+
+- `MAVEN_GPG_PRIVATE_KEY`: Armored GPG private key
+- `MAVEN_GPG_PASSPHRASE`: GPG key passphrase
+- `MAVEN_CENTRAL_USERNAME`: Sonatype JIRA username
+- `MAVEN_CENTRAL_PASSWORD`: Sonatype password or token
+
+### For GitHub Packages
+
+- `GITHUB_TOKEN`: Already provided by Actions (needs `packages: write` permission)
+
+---
+
+## Troubleshooting
+
+### "Component directory not found"
+Ensure the component folder exists at the monorepo root and matches the input exactly.
+
+### "Component does not have pom.xml"
+Verify `<component>/pom.xml` exists and is valid.
+
+### "Failed to determine current version"
+Check that `pom.xml` has valid `<version>` element and Maven can parse it.
+
+### Build fails
+Run locally to check: `cd <component> && mvn clean package`
+
+### Publishing fails
+- **Maven Central**: Verify GPG key is imported, passphrase is correct, credentials are valid
+- **GitHub Packages**: Verify `token` has `packages:write` permission and repository URL is correct
+
+### Git tag already exists
+Delete remote tag: `git push origin :refs/tags/<tag-name>` and retry
+
+---
+
+## Notes
+
+- **No maven-release-plugin**: This action implements custom version management. Don't use Maven Release Plugin profiles.
+- **Atomic commits**: Version bumps and updates are committed separately, allowing rollback if needed.
+- **Always use `@v1.0.0` or SHA**: Never use `@main` in production workflows.
+- **Dry-run by default**: `dry-run: 'true'` is the default for safety — explicitly set `'false'` to perform real release.
+- **Idempotent**: Safe to re-run; if version is already released, action will fail at build step (artifact already deployed).

--- a/actions/maven-monorepo-release/README.md
+++ b/actions/maven-monorepo-release/README.md
@@ -366,7 +366,8 @@ Run locally: `cd <component> && mvn clean package`
 ### Publishing fails
 
 - **Maven Central**: Verify GPG key is imported, passphrase is correct, and `maven-username`/`maven-password` are set
-- **GitHub Packages**: Verify `token` has `packages: write` permission and the repository URL in `distributionManagement` is correct
+- **GitHub Packages**: Verify `token` has `packages: write` permission and the repository URL in
+  `distributionManagement` is correct
 
 ### Git tag already exists
 

--- a/actions/maven-monorepo-release/README.md
+++ b/actions/maven-monorepo-release/README.md
@@ -50,9 +50,9 @@ Automates releasing individual Maven components from a monorepo with **independe
 | `token` | GitHub token for checkout and git operations | Yes | - |
 | `gpg-private-key` | Armored GPG private key (required for Maven Central) | No | - |
 | `gpg-passphrase` | GPG passphrase | No | - |
-| `maven-central-username` | Sonatype username (required for Maven Central) | No | - |
-| `maven-central-password` | Sonatype password or token (required for Maven Central) | No | - |
-| `maven-profile` | Maven profile to activate (e.g., `release`) | No | - |
+| `maven-username` | Sonatype username for Maven Central or GitHub username for GitHub packages | No | - |
+| `maven-password` | Sonatype password or token for Maven Central or GitHub token for GitHub packages | No | - |
+| `maven-profile` | Maven profile to activate (e.g., `github`) | No | - |
 | `update-parent-version` | Set to `'true'` to update parent version in child modules after parent release | No | `'false'` |
 
 ---
@@ -189,8 +189,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           gpg-passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-          maven-central-username: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          maven-central-password: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          maven-username: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          maven-password: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
 ```
 
 ### Example 3: Release with dependency updates
@@ -207,8 +207,8 @@ jobs:
     token: ${{ secrets.GITHUB_TOKEN }}
     gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
     gpg-passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-    maven-central-username: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-    maven-central-password: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+    maven-username: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+    maven-password: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
 ```
 
 ---

--- a/actions/maven-monorepo-release/README.md
+++ b/actions/maven-monorepo-release/README.md
@@ -1,8 +1,13 @@
 # 🚀 Maven Monorepo Release Action
 
-Automates releasing individual Maven components from a monorepo with **independent versioning per component**. Handles version bumping (major/minor/patch or explicit version), GPG signing, publishing to Maven Central or GitHub Packages, and automatic dependency updates within the monorepo.
+Release Maven components from a monorepo with independent versioning per component.
+Supports releasing individual components, parent, and BOM independently. Handles version
+bumping (major/minor/patch), GPG signing, and publishing to Maven Central or GitHub Packages.
+Dry-run mode available for validation.
 
-**Key difference from `maven-release`**: This action does NOT use Maven Release Plugin (which is incompatible with monorepos). Instead, it implements custom version management that handles:
+**Key difference from `maven-release`**: This action does NOT use Maven Release Plugin
+(which is incompatible with monorepos). Instead, it implements custom version management that handles:
+
 - Independent component versioning
 - Automatic dependency updates between monorepo components
 - GitHub releases with component-scoped tags (`component-name-version`)
@@ -14,22 +19,26 @@ Automates releasing individual Maven components from a monorepo with **independe
 ## Features
 
 ### Version Management
+
 - **Independent versioning**: Each component maintains its own version independent of others
 - **Flexible bumping**: Support for `major`, `minor`, `patch`, or explicit semantic versions (e.g., `1.2.3`)
 - **SNAPSHOT handling**: Automatically manages `-SNAPSHOT` versions between releases
 
 ### Publishing
-- **Dual targets**: Publish to Maven Central, GitHub Packages, or both
+
+- **Dual targets**: Publish to Maven Central (`central`), GitHub Packages (`github`), or both (`both`)
 - **GPG signing**: Optional GPG signing for Maven Central compliance
-- **GitHub releases**: Creates annotated git tags in format `<component>-<version>`
+- **Component-scoped tags**: Creates annotated git tags in format `<component>-<version>`
 
 ### Dependency Management
-- **Inter-module updates**: Automatically updates component versions in dependent modules within monorepo
-- **Parent versioning**: Option to update parent POM references in child modules
+
+- **Inter-module updates**: Automatically updates component versions in dependent modules within the monorepo
+- **Parent versioning**: Option to update parent POM references in child modules after parent release
 - **BOM management**: Full support for BOM (Bill of Materials) modules
 
 ### Safety & Validation
-- **Dry-run mode**: Build and validate without creating tags, commits, or pushing
+
+- **Dry-run mode**: Builds and deploys SNAPSHOT to target registry without version bump, tagging, or release commits
 - **Structure validation**: Ensures monorepo structure is correct before release
 - **Build verification**: Validates component builds successfully before releasing
 
@@ -39,21 +48,23 @@ Automates releasing individual Maven components from a monorepo with **independe
 
 | Name | Description | Required | Default |
 | --- | --- | --- | --- |
-| `component` | Component to release: `parent`, `bom`, or folder name (e.g., `my-component`) | Yes | - |
-| `version-type` | Bump type: `major`, `minor`, `patch`, or explicit version like `1.2.3` | Yes | `patch` |
-| `ref` | Branch to release from | No | `main` |
-| `publish-target` | Where to publish: `maven-central`, `github`, or `both` | No | `github` |
-| `java-version` | Java version (LTS: 21, 17, 11) | No | `21` |
-| `maven-version` | Maven version to use. Empty = use runner's pre-installed Maven | No | - |
-| `maven-args` | Additional Maven arguments for all invocations | No | `-DskipTests=true -Dmaven.javadoc.skip=true -B` |
-| `dry-run` | Set to `'false'` to perform actual release. `'true'` = validation only | No | `'true'` |
-| `token` | GitHub token for checkout and git operations | Yes | - |
-| `gpg-private-key` | Armored GPG private key (required for Maven Central) | No | - |
-| `gpg-passphrase` | GPG passphrase | No | - |
-| `maven-username` | Sonatype username for Maven Central or GitHub username for GitHub packages | No | - |
-| `maven-password` | Sonatype password or token for Maven Central or GitHub token for GitHub packages | No | - |
-| `maven-profile` | Maven profile to activate (e.g., `github`) | No | - |
-| `update-parent-version` | Set to `'true'` to update parent version in child modules after parent release | No | `'false'` |
+| `component` | Component to release. Use `parent`, `bom`, or the component folder name (e.g., `my-component`) | Yes | - |
+| `version-type` | Version bump type: `major`, `minor`, `patch`, or an explicit semver like `1.2.3` | Yes | `patch` |
+| `version-property` | Optional Maven property name to update alongside the version (e.g., `my.component.version`). When set, also runs `mvn versions:set-property` on dependent POM files. | No | - |
+| `ref` | Branch to create release from | No | `main` |
+| `publish-target` | Where to publish: `central` (requires GPG credentials), `github` (uses GITHUB\_TOKEN), or `both` | No | `github` |
+| `java-version` | Java version to set up (LTS recommended: `21`, `17`, `11`) | No | `21` |
+| `maven-version` | Maven version to install. When empty, the runner's pre-installed Maven is used | No | - |
+| `maven-args` | Additional Maven arguments appended to all invocations | No | `-DskipTests=true -Dmaven.javadoc.skip=true -B` |
+| `dry-run` | Set to `'false'` to perform the actual release. Default `'true'` builds and deploys a SNAPSHOT to the target registry without bumping versions, committing, or pushing tags | No | `'true'` |
+| `token` | GitHub token for repository checkout and git operations | Yes | - |
+| `gpg-private-key` | Armored GPG private key for artifact signing (required when `publish-target` is `central` or `both`) | No | - |
+| `gpg-passphrase` | Passphrase for the GPG private key | No | - |
+| `maven-username` | Maven Central (Sonatype) username for authentication | No | - |
+| `maven-password` | Maven Central (Sonatype) password or authentication token. Required when `publish-target` is `central` or `both` | No | - |
+| `maven-profile` | Maven profile to activate (e.g., `release`). Leave empty to skip | No | - |
+| `update-parent-version` | Set to `'true'` to automatically update the parent version reference in child modules after releasing the `parent` component. Ignored when `component` is not `parent` | No | `'false'` |
+| `skip-parent-check` | Set to `'true'` to skip validation that non-parent components inherit from the parent POM | No | `'false'` |
 
 ---
 
@@ -61,9 +72,9 @@ Automates releasing individual Maven components from a monorepo with **independe
 
 | Name | Description |
 | --- | --- |
-| `release-version` | Released version (e.g., `2.1.0`) |
-| `component-released` | Name of component released |
-| `artifacts` | Published artifact coordinates (groupId:artifactId:version) |
+| `release-version` | The released version (e.g., `2.1.0`). Set in both dry-run and release modes |
+| `component-released` | Name of the component that was released |
+| `artifacts` | Published artifact coordinates in `groupId:artifactId:version` format |
 
 ---
 
@@ -71,7 +82,7 @@ Automates releasing individual Maven components from a monorepo with **independe
 
 This action expects a Maven monorepo structured like:
 
-```
+```text
 monorepo-root/
 ├── pom.xml                    # Root aggregator POM (optional, lists modules)
 ├── parent/
@@ -89,193 +100,89 @@ monorepo-root/
 └── ...
 ```
 
-### Key requirements:
+### Key requirements
 
 1. **Root directory**: Each component lives in its own top-level folder (e.g., `parent`, `bom`, `my-component`)
-2. **Parent POM**: All non-parent components should inherit from `parent/pom.xml` via `<parent>` element
-3. **Independent versions**: Each component's `pom.xml` declares its own `<version>` (not inherited from parent)
-4. **Inter-dependencies**: Components can depend on other components within the monorepo
+1. **Parent POM**: All non-parent components should inherit from `parent/pom.xml` via `<parent>` element
+1. **Independent versions**: Each component's `pom.xml` declares its own `<version>` (not inherited from parent)
+1. **Inter-dependencies**: Components can depend on other components within the monorepo
 
 ---
 
-## Release Workflow
+## How it works
 
 ### Dry-run mode (default, `dry-run: 'true'`)
 
-1. Validates monorepo structure
-2. Builds component (runs `mvn clean package`)
-3. **Does NOT**: bump version, commit, tag, or push
-4. Useful for validation before committing to a release
+1. Validates monorepo structure and component existence
+1. Builds component (`mvn clean package`)
+1. Deploys SNAPSHOT artifact to the target registry
+1. **Does NOT**: bump version, commit, create tag, or push any changes
+1. Sets `release-version`, `component-released`, and `artifacts` outputs
 
 ### Release mode (`dry-run: 'false'`)
 
-1. **Get current version** from component's `pom.xml`
-2. **Bump version** based on `version-type` (major/minor/patch)
-3. **Update pom.xml** with release version
-4. **Build component** (`mvn clean package`)
-5. **Deploy** to Maven Central and/or GitHub Packages
-6. **Commit** release version change and push
-7. **Create git tag** in format `<component>-<version>` (e.g., `my-component-2.1.0`)
-8. **Update to next SNAPSHOT** version (e.g., `2.1.1-SNAPSHOT`)
-9. **Update dependencies** in other monorepo components (if configured)
-10. **Update parent version** in child modules (if component is parent and flag enabled)
+1. **Validates** monorepo structure
+1. **Gets current version** from component's `pom.xml` via `mvn help:evaluate`
+1. **Bumps version** based on `version-type` (major/minor/patch or explicit)
+1. **Updates pom.xml** with release version via `mvn versions:set`
+1. **Builds and deploys** to Maven Central and/or GitHub Packages
+1. **Commits** release version change: `chore(<component>): release version <X.Y.Z>`
+1. **Creates git tag** in format `<component>-<version>` (e.g., `my-component-2.1.0`)
+1. **Updates to next SNAPSHOT**: bumps patch version and appends `-SNAPSHOT`
+1. **Commits** SNAPSHOT bump: `chore(<component>): bump to next snapshot version <X.Y.Z-SNAPSHOT>`
+1. **Updates dependencies** in other monorepo components that reference this component
+1. **Updates parent version** in child modules (only when `component=parent` and `update-parent-version='true'`)
 
----
-
-## Usage Examples
-
-### Example 1: Release a component to GitHub Packages (dry-run)
-
-```yaml
-name: Release Component (Dry-Run)
-
-on:
-  workflow_dispatch:
-    inputs:
-      component:
-        description: 'Component to release'
-        required: true
-      version-type:
-        description: 'Version bump type'
-        required: true
-        type: choice
-        options: [major, minor, patch]
-
-jobs:
-  release:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      packages: write
-    steps:
-      - name: Release (Dry-Run)
-        uses: netcracker/qubership-workflow-hub/actions/maven-monorepo-release@v1.0.0
-        with:
-          component: ${{ inputs.component }}
-          version-type: ${{ inputs.version-type }}
-          dry-run: 'true'
-          token: ${{ secrets.GITHUB_TOKEN }}
-```
-
-### Example 2: Actual release to Maven Central
-
-```yaml
-name: Release to Maven Central
-
-on:
-  workflow_dispatch:
-    inputs:
-      component:
-        description: 'Component to release'
-        required: true
-      version:
-        description: 'Version (major, minor, patch, or explicit like 1.2.3)'
-        required: true
-
-jobs:
-  release:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      packages: write
-    steps:
-      - name: Release to Maven Central
-        uses: netcracker/qubership-workflow-hub/actions/maven-monorepo-release@v1.0.0
-        with:
-          component: ${{ inputs.component }}
-          version-type: ${{ inputs.version }}
-          publish-target: central
-          dry-run: 'false'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-          gpg-passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-          maven-username: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          maven-password: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-```
-
-### Example 3: Release with dependency updates
-
-```yaml
-- name: Release Parent and Update Children
-  uses: netcracker/qubership-workflow-hub/actions/maven-monorepo-release@v1.0.0
-  with:
-    component: parent
-    version-type: minor
-    publish-target: centarl
-    dry-run: 'false'
-    update-parent-version: 'true'
-    token: ${{ secrets.GITHUB_TOKEN }}
-    gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-    gpg-passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-    maven-username: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-    maven-password: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-```
-
----
-
-## Version Bumping Logic
+### Version bumping logic
 
 Given current version `2.1.3-SNAPSHOT`:
 
-| `version-type` | Result |
+| `version-type` | Released version |
 | --- | --- |
 | `patch` | `2.1.4` |
 | `minor` | `2.2.0` |
 | `major` | `3.0.0` |
 | `1.2.3` (explicit) | `1.2.3` |
 
-After release, automatically bumped to next SNAPSHOT (e.g., `2.1.4-SNAPSHOT`).
+After release, version is automatically bumped to next patch SNAPSHOT (e.g., `2.1.4-SNAPSHOT`).
 
 ---
 
-## Dependency Management
+## Additional Information
 
-### Inter-module dependency updates
+### `version-property` input
 
-When releasing a component that is a dependency for other components in the monorepo:
+When set, `update_dependency_version` also runs `mvn versions:set-property` on dependent POM
+files to update a named Maven property alongside the direct dependency version:
 
-1. Action scans all other `pom.xml` files for references to released component
-2. Automatically updates versions in dependent modules
-3. Commits changes with message: `chore(dependent-module): update component-name to X.Y.Z`
+```xml
+<!-- Example: if version-property is set to "my-lib.version" -->
+<properties>
+  <my-lib.version>2.1.0</my-lib.version>
+</properties>
+```
 
-**Example**: Releasing `my-lib:2.1.0` automatically updates `my-app` if it depends on `my-lib`.
+This is useful for monorepos that manage dependency versions through properties rather than
+inline `<version>` elements.
 
-### Parent version updates
+### `publish-target` values
 
-When releasing parent with `update-parent-version: 'true'`:
+| Value | Behaviour |
+| --- | --- |
+| `github` | Deploys via `mvn deploy -Drepo.id=github`. Requires `packages: write` permission and a valid `token` |
+| `central` | Deploys via `mvn deploy`. Requires `maven-username`, `maven-password`, and `gpg-private-key` |
+| `both` | Runs both `github` and `central` deployments in sequence |
 
-1. Action finds all modules with `<parent>` reference to released parent
-2. Updates their parent version to the released version
-3. Commits changes in each child module
+### pom.xml structure
 
----
-
-## Git Tags and Releases
-
-Tags are created in format: `<component-name>-<version>`
-
-Examples:
-- `my-lib-1.0.0`
-- `my-app-2.1.3`
-- `parent-1.5.0`
-- `bom-3.0.0`
-
-Each tag points to the commit that updated the pom.xml to the release version.
-
----
-
-## Configuration Requirements
-
-### pom.xml Structure
-
-Each component must have:
+Each component must declare its own `<version>`:
 
 ```xml
 <project>
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.example</groupId>
   <artifactId>my-component</artifactId>
-  <version>1.0.0</version>  <!-- Must be present and independently versioned -->
+  <version>1.0.0</version>
 
   <!-- For non-parent components, inherit from parent -->
   <parent>
@@ -284,7 +191,6 @@ Each component must have:
     <version>1.0.0</version>
   </parent>
 
-  <!-- Dependencies are OK and will be auto-updated -->
   <dependencies>
     <dependency>
       <groupId>com.example</groupId>
@@ -303,9 +209,9 @@ For Maven Central publishing, configure `~/.m2/settings.xml`:
 <settings>
   <servers>
     <server>
-      <id>maven-central</id>
-      <username>${env.MAVEN_CENTRAL_USERNAME}</username>
-      <password>${env.MAVEN_CENTRAL_PASSWORD}</password>
+      <id>central</id>
+      <username>${env.MAVEN_USERNAME}</username>
+      <password>${env.MAVEN_PASSWORD}</password>
     </server>
     <server>
       <id>github</id>
@@ -331,7 +237,7 @@ For Maven Central publishing, configure `~/.m2/settings.xml`:
 
 ### GitHub Packages publishing
 
-Add to parent `pom.xml`:
+Add a `distributionManagement` section to your POM:
 
 ```xml
 <distributionManagement>
@@ -343,50 +249,139 @@ Add to parent `pom.xml`:
 </distributionManagement>
 ```
 
+### Dependency update commit messages
+
+When this action updates dependent modules within the monorepo, it uses the following commit
+message format:
+
+```text
+chore(<component>): update dependencies on <groupId>:<artifactId> to <X.Y.Z>
+```
+
 ---
 
-## Secrets Required
+## Usage
+
+```yaml
+name: Release Maven Component
+
+on:
+  workflow_dispatch:
+    inputs:
+      component:
+        description: 'Component to release (parent, bom, or folder name)'
+        required: true
+      version-type:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        options: [major, minor, patch]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Release component
+        uses: netcracker/qubership-workflow-hub/actions/maven-monorepo-release@cabbb90e9471163cfac84bd50ff0296b2803b44c  # v2.3.0
+        with:
+          component: ${{ inputs.component }}
+          version-type: ${{ inputs.version-type }}
+          dry-run: 'false'
+          token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Release to Maven Central
+
+```yaml
+- name: Release to Maven Central
+  uses: netcracker/qubership-workflow-hub/actions/maven-monorepo-release@cabbb90e9471163cfac84bd50ff0296b2803b44c  # v2.3.0
+  with:
+    component: ${{ inputs.component }}
+    version-type: ${{ inputs.version-type }}
+    publish-target: central
+    dry-run: 'false'
+    token: ${{ secrets.GITHUB_TOKEN }}
+    gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+    gpg-passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+    maven-username: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+    maven-password: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+```
+
+### Release parent and update children
+
+```yaml
+- name: Release parent and update child modules
+  uses: netcracker/qubership-workflow-hub/actions/maven-monorepo-release@cabbb90e9471163cfac84bd50ff0296b2803b44c  # v2.3.0
+  with:
+    component: parent
+    version-type: minor
+    publish-target: central
+    dry-run: 'false'
+    update-parent-version: 'true'
+    token: ${{ secrets.GITHUB_TOKEN }}
+    gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+    gpg-passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+    maven-username: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+    maven-password: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+```
+
+---
+
+## Secrets required
 
 ### For Maven Central
 
 - `MAVEN_GPG_PRIVATE_KEY`: Armored GPG private key
 - `MAVEN_GPG_PASSPHRASE`: GPG key passphrase
-- `MAVEN_CENTRAL_USERNAME`: Sonatype JIRA username
+- `MAVEN_CENTRAL_USERNAME`: Sonatype username
 - `MAVEN_CENTRAL_PASSWORD`: Sonatype password or token
 
 ### For GitHub Packages
 
-- `GITHUB_TOKEN`: Already provided by Actions (needs `packages: write` permission)
+- `GITHUB_TOKEN`: Provided automatically by Actions — requires `packages: write` permission
 
 ---
 
 ## Troubleshooting
 
 ### "Component directory not found"
-Ensure the component folder exists at the monorepo root and matches the input exactly.
+
+Ensure the component folder exists at the monorepo root and matches the `component` input exactly.
 
 ### "Component does not have pom.xml"
-Verify `<component>/pom.xml` exists and is valid.
+
+Verify `<component>/pom.xml` exists and is valid XML.
 
 ### "Failed to determine current version"
-Check that `pom.xml` has valid `<version>` element and Maven can parse it.
+
+Check that `pom.xml` has a valid `<version>` element that Maven can parse.
 
 ### Build fails
-Run locally to check: `cd <component> && mvn clean package`
+
+Run locally: `cd <component> && mvn clean package`
 
 ### Publishing fails
-- **Maven Central**: Verify GPG key is imported, passphrase is correct, credentials are valid
-- **GitHub Packages**: Verify `token` has `packages:write` permission and repository URL is correct
+
+- **Maven Central**: Verify GPG key is imported, passphrase is correct, and `maven-username`/`maven-password` are set
+- **GitHub Packages**: Verify `token` has `packages: write` permission and the repository URL in `distributionManagement` is correct
 
 ### Git tag already exists
-Delete remote tag: `git push origin :refs/tags/<tag-name>` and retry
+
+Delete the remote tag and retry: `git push origin :refs/tags/<tag-name>`
 
 ---
 
 ## Notes
 
-- **No maven-release-plugin**: This action implements custom version management. Don't use Maven Release Plugin profiles.
-- **Atomic commits**: Version bumps and updates are committed separately, allowing rollback if needed.
-- **Always use `@v1.0.0` or SHA**: Never use `@main` in production workflows.
-- **Dry-run by default**: `dry-run: 'true'` is the default for safety — explicitly set `'false'` to perform real release.
-- **Idempotent**: Safe to re-run; if version is already released, action will fail at build step (artifact already deployed).
+- **No maven-release-plugin**: This action implements custom version management. Do not use
+  Maven Release Plugin profiles alongside it.
+- **Dry-run by default**: `dry-run: 'true'` is the default for safety — explicitly set `'false'`
+  to perform a real release.
+- **Atomic commits**: Version bumps, dependency updates, and SNAPSHOT bumps are each committed
+  separately, allowing targeted rollback.
+- Pin to a full 40-character commit SHA with the release tag as a trailing comment, e.g.
+  `@cabbb90e9471163cfac84bd50ff0296b2803b44c # v2.3.0`. The SHA is the immutable pin; the
+  comment shows which release it points to. Tags alone are mutable. Never use `@main` or short SHAs.

--- a/actions/maven-monorepo-release/action-script.sh
+++ b/actions/maven-monorepo-release/action-script.sh
@@ -171,6 +171,9 @@ update_dependency_version() {
     log_info "Updating $groupid:$artifactid to $new_version in $pom_file"
     mvn versions:use-dep-version -Dincludes="$groupid:$artifactid" \
         -DdepVersion="$new_version" -DgenerateBackupPoms=false -q || true
+    if [ ! -z "${VERSION_PROPERTY:-}" ]; then
+        mvn versions:set-property -Dproperty="${VERSION_PROPERTY:-}" -DnewVersion="$new_version" -DgenerateBackupPoms=false -q || true
+    fi
     git add "$(basename "$pom_file")"
     cd "$top_dir"
 }

--- a/actions/maven-monorepo-release/action-script.sh
+++ b/actions/maven-monorepo-release/action-script.sh
@@ -345,8 +345,6 @@ release_component() {
 
     # Build and deploy
     echo "[DEBUG] build_and_deploy args: component=$component, new_version=$new_version, publish_target=$publish_target, maven_args='$maven_args', maven_profile='$maven_profile'"
-    echo "[DEBUG] Current directory: $(pwd)"
-    echo "[DEBUG] Directory contents: $(ls -la)"
     build_and_deploy "$component" "$new_version" "$publish_target" "$maven_args" "$maven_profile"
 
     # Commit release version

--- a/actions/maven-monorepo-release/action-script.sh
+++ b/actions/maven-monorepo-release/action-script.sh
@@ -55,7 +55,7 @@ validate_inputs() {
 
     if [[ "$publish_target" == "central" ]]; then
         if [[ -z "${MAVEN_USERNAME:-}" ]] || [[ -z "${MAVEN_PASSWORD:-}" ]]; then
-            log_error "maven-central-username and maven-central-password required for Maven Central publishing"
+            log_error "maven-username and maven-password required for Maven Central publishing"
             exit 1
         fi
     fi

--- a/actions/maven-monorepo-release/action-script.sh
+++ b/actions/maven-monorepo-release/action-script.sh
@@ -358,6 +358,9 @@ release_component() {
     update_pom_version "$component" "$new_version"
 
     # Build and deploy
+    echo "[DEBUG] build_and_deploy args: component=$component, new_version=$new_version, publish_target=$publish_target, maven_args='$maven_args', maven_profile='$maven_profile'"
+    echo "[DEBUG] Current directory: $(pwd)"
+    echo "[DEBUG] Directory contents: $(ls -la)"
     build_and_deploy "$component" "$new_version" "$publish_target" "$maven_args" "$maven_profile"
 
     # Commit release version

--- a/actions/maven-monorepo-release/action-script.sh
+++ b/actions/maven-monorepo-release/action-script.sh
@@ -1,0 +1,423 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info() {
+    echo -e "${BLUE}ℹ️ $1${NC}"
+}
+
+log_success() {
+    echo -e "${GREEN}✅ $1${NC}"
+}
+
+log_error() {
+    echo -e "${RED}❌ $1${NC}" >&2
+}
+
+log_warning() {
+    echo -e "${YELLOW}⚠️ $1${NC}"
+}
+
+# Validate inputs
+validate_inputs() {
+    local component=$1
+    local version_type=$2
+    local publish_target=$3
+    local token=$4
+
+    if [[ -z "$component" ]]; then
+        log_error "component input is required"
+        exit 1
+    fi
+
+    if [[ -z "$token" ]]; then
+        log_error "token input is required"
+        exit 1
+    fi
+
+    # Validate version type (allow: major, minor, patch, or semantic version like 1.2.3)
+    if ! [[ "$version_type" =~ ^(major|minor|patch|[0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+        log_error "version-type must be 'major', 'minor', 'patch', or a semantic version like '1.2.3'"
+        exit 1
+    fi
+
+    # Validate publish target
+    if ! [[ "$publish_target" =~ ^(central|github|both)$ ]]; then
+        log_error "publish-target must be 'central', 'github', or 'both'"
+        exit 1
+    fi
+
+    if [[ "$publish_target" == "central" ]]; then
+        if [[ -z "${MAVEN_USERNAME:-}" ]] || [[ -z "${MAVEN_PASSWORD:-}" ]]; then
+            log_error "maven-central-username and maven-central-password required for Maven Central publishing"
+            exit 1
+        fi
+    fi
+
+    log_success "Input validation passed"
+}
+
+# Validate monorepo structure
+validate_monorepo_structure() {
+    local component=$1
+
+    log_info "Validating monorepo structure..."
+
+    # Check if component directory exists
+    if [[ ! -d "$component" ]]; then
+        log_error "Component directory '$component' not found"
+        exit 1
+    fi
+
+    # Check if component has pom.xml
+    if [[ ! -f "$component/pom.xml" ]]; then
+        log_error "Component '$component' does not have pom.xml"
+        exit 1
+    fi
+
+    # For non-parent components, validate parent reference
+    if [[ "$component" != "parent" ]]; then
+        local parent_groupid
+        parent_groupid=$(cd "$component" && mvn help:evaluate -Dexpression=project.parent.groupId -q -DforceStdout 2>/dev/null || echo "")
+
+        if [[ -z "$parent_groupid" ]]; then
+            log_warning "Component '$component' does not have a parent POM reference"
+        else
+            log_success "Component '$component' inherits from parent: $parent_groupid"
+        fi
+    fi
+
+    log_success "Monorepo structure validation passed"
+}
+
+# Get current version of component
+get_current_version() {
+    local component=$1
+    cd "$component"
+    mvn help:evaluate -Dexpression=project.version -q -DforceStdout 2>/dev/null || echo ""
+}
+
+# Parse version and bump it
+bump_version() {
+    local current=$1
+    local bump_type=$2
+
+    # Remove -SNAPSHOT suffix if present
+    local base_version="${current%-SNAPSHOT}"
+
+    # Parse version components
+    local IFS='.'
+    read -r major minor patch <<< "$base_version"
+
+    major=${major:-0}
+    minor=${minor:-0}
+    patch=${patch:-0}
+
+    case "$bump_type" in
+        major)
+            echo "$((major + 1)).0.0"
+            ;;
+        minor)
+            echo "$major.$((minor + 1)).0"
+            ;;
+        patch)
+            echo "$major.$minor.$((patch + 1))"
+            ;;
+        *)
+            # Explicit version
+            echo "$bump_type"
+            ;;
+    esac
+}
+
+# Get next snapshot version
+get_next_snapshot_version() {
+    local release_version=$1
+    echo "${release_version}-SNAPSHOT"
+}
+
+# Update version in pom.xml using Maven
+update_pom_version() {
+    local component=$1
+    local new_version=$2
+
+    log_info "Updating version in $component/pom.xml to $new_version"
+    cd "$component"
+    mvn versions:set -DnewVersion="$new_version" -DgenerateBackupPoms=false -q
+    log_success "Version updated to $new_version"
+}
+
+# Find all inter-module dependencies
+find_monorepo_dependencies() {
+    local component=$1
+    local search_groupid=$2
+    local search_artifactid=$3
+
+    log_info "Finding references to $search_groupid:$search_artifactid in other components..."
+
+    # Search all pom.xml files for the dependency (excluding the component itself)
+    local found_count=0
+    while IFS= read -r pom_file; do
+        local component_dir=$(dirname "$pom_file")
+
+        # Skip the component itself and target directories
+        if [[ "$component_dir" == "$component" ]] || [[ "$component_dir" == *"/target"* ]]; then
+            continue
+        fi
+
+        # Check if pom.xml contains the dependency
+        if grep -q "<artifactId>$search_artifactid</artifactId>" "$pom_file"; then
+            # Verify it's the same groupId
+            if grep -q "<groupId>$search_groupid</groupId>" "$pom_file"; then
+                echo "$component_dir"
+                ((found_count++))
+            fi
+        fi
+    done < <(find . -name "pom.xml" -type f -not -path "*/target/*")
+
+    return $found_count
+}
+
+# Update dependency version in a pom.xml file
+update_dependency_version() {
+    local pom_file=$1
+    local groupid=$2
+    local artifactid=$3
+    local new_version=$4
+
+    cd "$(dirname "$pom_file")"
+    log_info "Updating $groupid:$artifactid to $new_version in $(basename $pom_file)"
+    mvn versions:use-dep-version -Dincludes="$groupid:$artifactid" \
+        -DdepVersion="$new_version" -DgenerateBackupPoms=false -q || true
+}
+
+# Create git tag
+create_git_tag() {
+    local component=$1
+    local version=$2
+    local tag_name="${component}-${version}"
+
+    log_info "Creating git tag: $tag_name"
+
+    git config --global user.name "qubership-actions[bot]"
+    git config --global user.email "qubership-actions[bot]@users.noreply.github.com"
+
+    git tag -a "$tag_name" -m "Release $component version $version"
+    git push origin "$tag_name"
+
+    log_success "Tag $tag_name created and pushed"
+}
+
+# Commit version changes
+commit_version_changes() {
+    local component=$1
+    local message=$2
+
+    log_info "Committing version changes: $message"
+
+    git config --global user.name "qubership-actions[bot]"
+    git config --global user.email "qubership-actions[bot]@users.noreply.github.com"
+
+    git add "$component/pom.xml"
+
+    # Check if there are changes to commit
+    if git diff --cached --quiet; then
+        log_warning "No changes to commit"
+        return 0
+    fi
+
+    git commit -m "$message"
+    git push origin
+
+    log_success "Changes committed and pushed"
+}
+
+# Build and deploy component
+build_and_deploy() {
+    local component=$1
+    local version=$2
+    local publish_target=$3
+    local maven_args=$4
+    local maven_profile=$5
+
+    log_info "Building component $component version $version..."
+
+    cd "$component"
+
+    # Build command
+    local build_cmd="mvn clean package $maven_args"
+    [[ -n "$maven_profile" ]] && build_cmd="$build_cmd -P$maven_profile"
+
+    if ! eval "$build_cmd"; then
+        log_error "Build failed for $component"
+        return 1
+    fi
+
+    log_success "Build successful"
+
+    # Deploy
+    if [[ "$publish_target" == "github" ]]; then
+        log_info "Deploying to GitHub Packages..."
+        local deploy_cmd="mvn deploy -DskipTests $maven_args -Drepo.id=github"
+        [[ -n "$maven_profile" ]] && deploy_cmd="$deploy_cmd -P$maven_profile"
+
+        if ! eval "$deploy_cmd"; then
+            log_error "GitHub deployment failed"
+            return 1
+        fi
+        log_success "GitHub deployment successful"
+    fi
+
+    if [[ "$publish_target" == "central" ]]; then
+        log_info "Deploying to Maven Central..."
+        local deploy_cmd="mvn deploy -DskipTests $maven_args"
+        [[ -n "$maven_profile" ]] && deploy_cmd="$deploy_cmd -P$maven_profile"
+
+        if ! eval "$deploy_cmd"; then
+            log_error "Maven Central deployment failed"
+            return 1
+        fi
+        log_success "Maven Central deployment successful"
+    fi
+}
+
+# Get component info from pom.xml
+get_component_info() {
+    local component=$1
+
+    cd "$component"
+
+    local groupid
+    local artifactid
+
+    groupid=$(mvn help:evaluate -Dexpression=project.groupId -q -DforceStdout 2>/dev/null || echo "")
+    artifactid=$(mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout 2>/dev/null || echo "")
+
+    echo "$groupid:$artifactid"
+}
+
+# Release component
+release_component() {
+    local component=$1
+    local version_type=$2
+    local publish_target=$3
+    local dry_run=$4
+    local maven_profile=$5
+    local maven_args=$6
+    local update_parent_version=$7
+
+    log_info "=========================================="
+    log_info "Starting release of component: $component"
+    log_info "=========================================="
+
+    # Get current version
+    local current_version
+    current_version=$(get_current_version "$component")
+
+    if [[ -z "$current_version" ]]; then
+        log_error "Failed to determine current version"
+        exit 1
+    fi
+
+    log_info "Current version: $current_version"
+
+    # Calculate new version
+    local new_version
+    new_version=$(bump_version "$current_version" "$version_type")
+
+    log_success "Release version: $new_version"
+
+    # Get component info
+    local component_info
+    component_info=$(get_component_info "$component")
+
+    if [[ "$dry_run" != "false" ]]; then
+        log_warning "DRY RUN MODE - No changes will be committed or pushed"
+        log_info "Would build and deploy version $new_version"
+
+        cd "$component"
+        log_info "Building component..."
+        local build_cmd="mvn clean package $maven_args"
+        [[ -n "$maven_profile" ]] && build_cmd="$build_cmd -P$maven_profile"
+        eval "$build_cmd"
+
+        log_success "Dry run validation successful"
+        echo "RELEASE_VERSION=$new_version" >> "$GITHUB_OUTPUT"
+        echo "COMPONENT_RELEASED=$component" >> "$GITHUB_OUTPUT"
+        echo "ARTIFACTS=$component_info:$new_version" >> "$GITHUB_OUTPUT"
+        return 0
+    fi
+
+    # Update version in pom.xml
+    update_pom_version "$component" "$new_version"
+
+    # Build and deploy
+    build_and_deploy "$component" "$new_version" "$publish_target" "$maven_args" "$maven_profile"
+
+    # Commit release version
+    commit_version_changes "$component" "chore($component): release version $new_version"
+
+    # Create git tag
+    create_git_tag "$component" "$new_version"
+
+    # Update next snapshot version in pom.xml
+    local next_snapshot
+    next_snapshot=$(get_next_snapshot_version "$new_version")
+    update_pom_version "$component" "$next_snapshot"
+
+    # Commit snapshot version
+    commit_version_changes "$component" "chore($component): bump to next snapshot version $next_snapshot"
+
+    # Update parent version in other components if this was a parent release
+    if [[ "$component" == "parent" ]] && [[ "$update_parent_version" == "true" ]]; then
+        log_info "Updating parent version reference in other components..."
+
+        local parent_info
+        parent_info=$(get_component_info "parent")
+
+        # Find all components that reference parent
+        while IFS= read -r dep_component; do
+            log_info "Updating $dep_component to use parent version $new_version"
+            update_dependency_version "$dep_component/pom.xml" "${parent_info%:*}" "${parent_info#*:}" "$new_version"
+            update_pom_version "$dep_component" "$(get_current_version "$dep_component")"
+        done < <(find . -maxdepth 2 -name "pom.xml" -type f -not -path "*/target/*" \
+            -exec grep -l "parent" {} \; | xargs -I {} dirname {} | sort -u)
+    fi
+
+    # Update dependencies in other components if they depend on this component
+    # if [[ "$component" != "parent" ]] && [[ "$component" != "bom" ]]; then
+        log_info "Checking for internal dependencies on $component..."
+
+        local comp_info
+        comp_info=$(get_component_info "$component")
+        local groupid="${comp_info%:*}"
+        local artifactid="${comp_info#*:}"
+
+        while IFS= read -r dep_component; do
+            log_info "Updating dependency in $dep_component..."
+            update_dependency_version "$dep_component/pom.xml" "$groupid" "$artifactid" "$new_version"
+            commit_version_changes "$dep_component" "chore($dep_component): update $artifactid to $new_version"
+        done < <(find_monorepo_dependencies "$component" "$groupid" "$artifactid" 2>/dev/null || true)
+    # fi
+
+    log_success "=========================================="
+    log_success "Release of $component completed successfully!"
+    log_success "Release version: $new_version"
+    log_success "=========================================="
+
+    echo "RELEASE_VERSION=$new_version" >> "$GITHUB_OUTPUT"
+    echo "COMPONENT_RELEASED=$component" >> "$GITHUB_OUTPUT"
+    echo "ARTIFACTS=$component_info:$new_version" >> "$GITHUB_OUTPUT"
+}
+
+# Export functions for sourcing
+export -f log_info log_success log_error log_warning validate_inputs validate_monorepo_structure
+export -f get_current_version bump_version get_next_snapshot_version update_pom_version
+export -f find_monorepo_dependencies update_dependency_version create_git_tag commit_version_changes
+export -f build_and_deploy get_component_info release_component

--- a/actions/maven-monorepo-release/action-script.sh
+++ b/actions/maven-monorepo-release/action-script.sh
@@ -156,6 +156,7 @@ update_pom_version() {
     mvn versions:set -DnewVersion="$new_version" -DgenerateBackupPoms=false -q
     log_success "Version updated to $new_version"
     cd "$top_dir"
+    git add "$component/pom.xml"
 }
 
 # Update dependency version in a pom.xml file
@@ -170,6 +171,7 @@ update_dependency_version() {
     log_info "Updating $groupid:$artifactid to $new_version in $(basename $pom_file)"
     mvn versions:use-dep-version -Dincludes="$groupid:$artifactid" \
         -DdepVersion="$new_version" -DgenerateBackupPoms=false -q || true
+    git add "$(basename "$pom_file")"
     cd "$top_dir"
 }
 
@@ -191,16 +193,16 @@ create_git_tag() {
 }
 
 # Commit version changes
-commit_version_changes() {
+commit_changes() {
     local component=$1
     local message=$2
 
-    log_info "Committing version changes: $message"
+    log_info "Committing changes: $message"
 
     git config --global user.name "qubership-actions[bot]"
     git config --global user.email "qubership-actions[bot]@users.noreply.github.com"
 
-    git add "$component/pom.xml"
+    # git add "$component/pom.xml"
 
     # Check if there are changes to commit
     if git diff --cached --quiet; then
@@ -345,7 +347,7 @@ release_component() {
     build_and_deploy "$component" "$new_version" "$publish_target" "$maven_args" "$maven_profile"
 
     # Commit release version
-    commit_version_changes "$component" "chore($component): release version $new_version"
+    commit_changes "$component" "chore($component): release version $new_version"
 
     # Create git tag
     create_git_tag "$component" "$new_version"
@@ -356,7 +358,7 @@ release_component() {
     update_pom_version "$component" "$next_snapshot"
 
     # Commit snapshot version
-    commit_version_changes "$component" "chore($component): bump to next snapshot version $next_snapshot"
+    commit_changes "$component" "chore($component): bump to next snapshot version $next_snapshot"
 
     # Update parent version in other components if this was a parent release
     if [[ "$component" == "parent" ]] && [[ "$update_parent_version" == "true" ]]; then
@@ -387,7 +389,7 @@ release_component() {
     done < <(find . -name "pom.xml" -type f -not -path "*/target/*" -not -path "./$component/*")
 
     # Commit dependency updates
-    commit_version_changes "$dep_component" "chore($dep_component): update $artifactid to $new_version"
+    commit_changes "$dep_component" "chore($dep_component): update $artifactid to $new_version"
 
     log_success "=========================================="
     log_success "Release of $component completed successfully!"
@@ -402,5 +404,5 @@ release_component() {
 # Export functions for sourcing
 export -f log_info log_success log_error log_warning validate_inputs validate_monorepo_structure
 export -f get_current_version bump_version get_next_snapshot_version update_pom_version
-export -f update_dependency_version create_git_tag commit_version_changes
+export -f update_dependency_version create_git_tag commit_changes
 export -f build_and_deploy get_component_info release_component

--- a/actions/maven-monorepo-release/action-script.sh
+++ b/actions/maven-monorepo-release/action-script.sh
@@ -168,7 +168,7 @@ update_dependency_version() {
     local new_version=$4
 
     cd "$(dirname "$pom_file")"
-    log_info "Updating $groupid:$artifactid to $new_version in $(basename $pom_file)"
+    log_info "Updating $groupid:$artifactid to $new_version in $pom_file"
     mvn versions:use-dep-version -Dincludes="$groupid:$artifactid" \
         -DdepVersion="$new_version" -DgenerateBackupPoms=false -q || true
     git add "$(basename "$pom_file")"

--- a/actions/maven-monorepo-release/action-script.sh
+++ b/actions/maven-monorepo-release/action-script.sh
@@ -83,9 +83,10 @@ validate_monorepo_structure() {
 
     # For non-parent components, validate parent reference
     if [[ "$component" != "parent" ]]; then
+        local top_dir=$(pwd)
         local parent_groupid
         parent_groupid=$(cd "$component" && mvn help:evaluate -Dexpression=project.parent.groupId -q -DforceStdout 2>/dev/null || echo "")
-
+        cd "$top_dir"
         if [[ -z "$parent_groupid" ]]; then
             log_warning "Component '$component' does not have a parent POM reference"
         else
@@ -98,9 +99,11 @@ validate_monorepo_structure() {
 
 # Get current version of component
 get_current_version() {
+    local top_dir=$(pwd)
     local component=$1
     cd "$component"
     mvn help:evaluate -Dexpression=project.version -q -DforceStdout 2>/dev/null || echo ""
+    cd "$top_dir"
 }
 
 # Parse version and bump it
@@ -144,6 +147,7 @@ get_next_snapshot_version() {
 
 # Update version in pom.xml using Maven
 update_pom_version() {
+    local top_dir=$(pwd)
     local component=$1
     local new_version=$2
 
@@ -151,6 +155,7 @@ update_pom_version() {
     cd "$component"
     mvn versions:set -DnewVersion="$new_version" -DgenerateBackupPoms=false -q
     log_success "Version updated to $new_version"
+    cd "$top_dir"
 }
 
 # Find all inter-module dependencies
@@ -240,6 +245,7 @@ commit_version_changes() {
 
 # Build and deploy component
 build_and_deploy() {
+    local top_dir=$(pwd)
     local component=$1
     local version=$2
     local publish_target=$3
@@ -285,10 +291,13 @@ build_and_deploy() {
         fi
         log_success "Maven Central deployment successful"
     fi
+
+    cd "$top_dir"
 }
 
 # Get component info from pom.xml
 get_component_info() {
+    local top_dir=$(pwd)
     local component=$1
 
     cd "$component"
@@ -300,6 +309,7 @@ get_component_info() {
     artifactid=$(mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout 2>/dev/null || echo "")
 
     echo "$groupid:$artifactid"
+    cd "$top_dir"
 }
 
 # Release component

--- a/actions/maven-monorepo-release/action-script.sh
+++ b/actions/maven-monorepo-release/action-script.sh
@@ -158,39 +158,9 @@ update_pom_version() {
     cd "$top_dir"
 }
 
-# Find all inter-module dependencies
-find_monorepo_dependencies() {
-    local component=$1
-    local search_groupid=$2
-    local search_artifactid=$3
-
-    log_info "Finding references to $search_groupid:$search_artifactid in other components..."
-
-    # Search all pom.xml files for the dependency (excluding the component itself)
-    local found_count=0
-    while IFS= read -r pom_file; do
-        local component_dir=$(dirname "$pom_file")
-
-        # Skip the component itself and target directories
-        if [[ "$component_dir" == "$component" ]] || [[ "$component_dir" == *"/target"* ]]; then
-            continue
-        fi
-
-        # Check if pom.xml contains the dependency
-        if grep -q "<artifactId>$search_artifactid</artifactId>" "$pom_file"; then
-            # Verify it's the same groupId
-            if grep -q "<groupId>$search_groupid</groupId>" "$pom_file"; then
-                echo "$component_dir"
-                ((found_count++))
-            fi
-        fi
-    done < <(find . -name "pom.xml" -type f -not -path "*/target/*")
-
-    return $found_count
-}
-
 # Update dependency version in a pom.xml file
 update_dependency_version() {
+    local top_dir=$(pwd)
     local pom_file=$1
     local groupid=$2
     local artifactid=$3
@@ -200,6 +170,7 @@ update_dependency_version() {
     log_info "Updating $groupid:$artifactid to $new_version in $(basename $pom_file)"
     mvn versions:use-dep-version -Dincludes="$groupid:$artifactid" \
         -DdepVersion="$new_version" -DgenerateBackupPoms=false -q || true
+    cd "$top_dir"
 }
 
 # Create git tag
@@ -404,20 +375,19 @@ release_component() {
     fi
 
     # Update dependencies in other components if they depend on this component
-    # if [[ "$component" != "parent" ]] && [[ "$component" != "bom" ]]; then
-        log_info "Checking for internal dependencies on $component..."
+    log_info "Checking for internal dependencies on $component..."
 
-        local comp_info
-        comp_info=$(get_component_info "$component")
-        local groupid="${comp_info%:*}"
-        local artifactid="${comp_info#*:}"
+    local comp_info
+    comp_info=$(get_component_info "$component")
+    local groupid="${comp_info%:*}"
+    local artifactid="${comp_info#*:}"
 
-        while IFS= read -r dep_component; do
-            log_info "Updating dependency in $dep_component..."
-            update_dependency_version "$dep_component/pom.xml" "$groupid" "$artifactid" "$new_version"
-            commit_version_changes "$dep_component" "chore($dep_component): update $artifactid to $new_version"
-        done < <(find_monorepo_dependencies "$component" "$groupid" "$artifactid" 2>/dev/null || true)
-    # fi
+    while IFS= read -r pom_file; do
+        update_dependency_version "$pom_file" "$groupid" "$artifactid" "$new_version"
+    done < <(find . -name "pom.xml" -type f -not -path "*/target/*" -not -path "./$component/*")
+
+    # Commit dependency updates
+    commit_version_changes "$dep_component" "chore($dep_component): update $artifactid to $new_version"
 
     log_success "=========================================="
     log_success "Release of $component completed successfully!"
@@ -432,5 +402,5 @@ release_component() {
 # Export functions for sourcing
 export -f log_info log_success log_error log_warning validate_inputs validate_monorepo_structure
 export -f get_current_version bump_version get_next_snapshot_version update_pom_version
-export -f find_monorepo_dependencies update_dependency_version create_git_tag commit_version_changes
+export -f update_dependency_version create_git_tag commit_version_changes
 export -f build_and_deploy get_component_info release_component

--- a/actions/maven-monorepo-release/action-script.sh
+++ b/actions/maven-monorepo-release/action-script.sh
@@ -389,7 +389,7 @@ release_component() {
     done < <(find . -name "pom.xml" -type f -not -path "*/target/*" -not -path "./$component/*")
 
     # Commit dependency updates
-    commit_changes "$dep_component" "chore($dep_component): update $artifactid to $new_version"
+    commit_changes "$component" "chore($component): update dependencies on $groupid:$artifactid to $new_version"
 
     log_success "=========================================="
     log_success "Release of $component completed successfully!"

--- a/actions/maven-monorepo-release/action-script.sh
+++ b/actions/maven-monorepo-release/action-script.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+TOP_DIR="${GITHUB_WORKSPACE}"
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -83,10 +85,9 @@ validate_monorepo_structure() {
 
     # For non-parent components, validate parent reference
     if [[ "$component" != "parent" ]]; then
-        local top_dir=$(pwd)
         local parent_groupid
         parent_groupid=$(cd "$component" && mvn help:evaluate -Dexpression=project.parent.groupId -q -DforceStdout 2>/dev/null || echo "")
-        cd "$top_dir"
+        cd "$TOP_DIR"
         if [[ -z "$parent_groupid" ]]; then
             log_warning "Component '$component' does not have a parent POM reference"
         else
@@ -99,11 +100,10 @@ validate_monorepo_structure() {
 
 # Get current version of component
 get_current_version() {
-    local top_dir=$(pwd)
     local component=$1
     cd "$component"
     mvn help:evaluate -Dexpression=project.version -q -DforceStdout 2>/dev/null || echo ""
-    cd "$top_dir"
+    cd "$TOP_DIR"
 }
 
 # Parse version and bump it
@@ -147,7 +147,6 @@ get_next_snapshot_version() {
 
 # Update version in pom.xml using Maven
 update_pom_version() {
-    local top_dir=$(pwd)
     local component=$1
     local new_version=$2
 
@@ -155,13 +154,12 @@ update_pom_version() {
     cd "$component"
     mvn versions:set -DnewVersion="$new_version" -DgenerateBackupPoms=false -q
     log_success "Version updated to $new_version"
-    cd "$top_dir"
+    cd "$TOP_DIR"
     git add "$component/pom.xml"
 }
 
 # Update dependency version in a pom.xml file
 update_dependency_version() {
-    local top_dir=$(pwd)
     local pom_file=$1
     local groupid=$2
     local artifactid=$3
@@ -175,7 +173,7 @@ update_dependency_version() {
         mvn versions:set-property -Dproperty="${VERSION_PROPERTY:-}" -DnewVersion="$new_version" -DgenerateBackupPoms=false -q || true
     fi
     git add "$(basename "$pom_file")"
-    cd "$top_dir"
+    cd "$TOP_DIR"
 }
 
 # Create git tag
@@ -221,7 +219,6 @@ commit_changes() {
 
 # Build and deploy component
 build_and_deploy() {
-    local top_dir=$(pwd)
     local component=$1
     local version=$2
     local publish_target=$3
@@ -268,12 +265,11 @@ build_and_deploy() {
         log_success "Maven Central deployment successful"
     fi
 
-    cd "$top_dir"
+    cd "$TOP_DIR"
 }
 
 # Get component info from pom.xml
 get_component_info() {
-    local top_dir=$(pwd)
     local component=$1
 
     cd "$component"
@@ -285,7 +281,7 @@ get_component_info() {
     artifactid=$(mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout 2>/dev/null || echo "")
 
     echo "$groupid:$artifactid"
-    cd "$top_dir"
+    cd "$TOP_DIR"
 }
 
 # Release component
@@ -334,9 +330,11 @@ release_component() {
         eval "$build_cmd"
 
         log_success "Dry run validation successful"
-        echo "RELEASE_VERSION=$new_version" >> "$GITHUB_OUTPUT"
-        echo "COMPONENT_RELEASED=$component" >> "$GITHUB_OUTPUT"
-        echo "ARTIFACTS=$component_info:$new_version" >> "$GITHUB_OUTPUT"
+        {
+            echo "RELEASE_VERSION=$new_version"
+            echo "COMPONENT_RELEASED=$component"
+            echo "ARTIFACTS=$component_info:$new_version"
+        } >> "$GITHUB_OUTPUT"
         return 0
     fi
 
@@ -374,7 +372,7 @@ release_component() {
             update_dependency_version "$dep_component/pom.xml" "${parent_info%:*}" "${parent_info#*:}" "$new_version"
             update_pom_version "$dep_component" "$(get_current_version "$dep_component")"
         done < <(find . -maxdepth 2 -name "pom.xml" -type f -not -path "*/target/*" \
-            -exec grep -l "parent" {} \; | xargs -I {} dirname {} | sort -u)
+            -exec grep -lq "parent" {} \; -printf '%h\n' | sort -u)
     fi
 
     # Update dependencies in other components if they depend on this component
@@ -397,9 +395,11 @@ release_component() {
     log_success "Release version: $new_version"
     log_success "=========================================="
 
-    echo "RELEASE_VERSION=$new_version" >> "$GITHUB_OUTPUT"
-    echo "COMPONENT_RELEASED=$component" >> "$GITHUB_OUTPUT"
-    echo "ARTIFACTS=$component_info:$new_version" >> "$GITHUB_OUTPUT"
+    {
+        echo "RELEASE_VERSION=$new_version"
+        echo "COMPONENT_RELEASED=$component"
+        echo "ARTIFACTS=$component_info:$new_version"
+    } >> "$GITHUB_OUTPUT"
 }
 
 # Export functions for sourcing

--- a/actions/maven-monorepo-release/action.yaml
+++ b/actions/maven-monorepo-release/action.yaml
@@ -49,7 +49,7 @@ inputs:
     description: "Additional Maven arguments for all invocations"
     required: false
     type: string
-    default: "-DskipTests=true -Dmaven.javadoc.skip=true -B"
+    default: "-B"
   dry-run:
     description: |
       Set to 'false' to perform actual release. Default 'true' validates build without pushing.

--- a/actions/maven-monorepo-release/action.yaml
+++ b/actions/maven-monorepo-release/action.yaml
@@ -1,0 +1,174 @@
+---
+name: Maven Monorepo Release
+description: |
+  Release Maven components from a monorepo with independent versioning per component.
+  Supports releasing individual components, parent, and BOM independently. Handles version
+  bumping (major/minor/patch), GPG signing, Maven release plugin, and publishing to Maven
+  Central or GitHub Packages. Dry-run mode available for validation.
+
+inputs:
+  component:
+    description: |
+      Component to release. Use 'parent', 'bom', or the component folder name (e.g., 'my-component').
+      For monorepos with structure: parent/, bom/, component1/, component2/, etc.
+    required: true
+    type: string
+  version-type:
+    description: "Version bump type: major, minor, or patch"
+    required: true
+    type: string
+    default: "patch"
+  ref:
+    description: "Branch to create release from"
+    required: false
+    type: string
+    default: "main"
+  publish-target:
+    description: |
+      Where to publish: 'central' (requires gpg-private-key), 'github' (uses GITHUB_TOKEN).
+      For Maven Central, requires MAVEN_USERNAME and MAVEN_PASSWORD credentials.
+    required: false
+    type: string
+    default: "github"
+  java-version:
+    description: "Java version (LTS recommended: 21, 17, 11)"
+    required: false
+    type: string
+    default: "21"
+  maven-version:
+    description: "Maven version to use. When empty, uses pre-installed Maven on runner"
+    required: false
+    type: string
+  maven-args:
+    description: "Additional Maven arguments for all invocations"
+    required: false
+    type: string
+    default: "-DskipTests=true -Dmaven.javadoc.skip=true -B"
+  dry-run:
+    description: |
+      Set to 'false' to perform actual release. Default 'true' validates build without pushing.
+      In dry-run: builds and deploys SNAPSHOT to target registry without version bump or tagging.
+    required: false
+    type: string
+    default: "true"
+  token:
+    description: "GitHub token for repository checkout and git operations"
+    required: true
+    type: string
+  gpg-private-key:
+    description: "Armored GPG private key for artifact signing (required for Maven Central)"
+    required: false
+    type: string
+  gpg-passphrase:
+    description: "Passphrase for GPG private key"
+    required: false
+    type: string
+  maven-central-username:
+    description: "Maven Central (Sonatype) username for authentication"
+    required: false
+    type: string
+  maven-central-password:
+    description: "Maven Central (Sonatype) password or authentication token"
+    required: false
+    type: string
+  maven-profile:
+    description: "Maven profile to activate (e.g., 'release'). Leave empty to skip"
+    required: false
+    type: string
+  update-parent-version:
+    description: |
+      Set to 'true' to automatically update parent version reference in other components
+      after releasing the parent. Only relevant when component='parent'.
+    required: false
+    type: string
+    default: "false"
+  skip-parent-check:
+    description: |
+      Set to 'true' to skip validation that components inherit from parent POM.
+      Only relevant when releasing a non-parent component.
+    required: false
+    type: string
+    default: "false"
+
+outputs:
+  release-version:
+    description: "The released version (e.g., 2.1.0)"
+    value: ${{ steps.release.outputs.RELEASE_VERSION }}
+  component-released:
+    description: "Component that was released"
+    value: ${{ steps.release.outputs.COMPONENT_RELEASED }}
+  artifacts:
+    description: "Comma-separated list of published artifact coordinates (groupId:artifactId:version)"
+    value: ${{ steps.release.outputs.ARTIFACTS }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Validate inputs
+      run: |
+        . ${GITHUB_ACTION_PATH}/action-script.sh
+        validate_inputs "$COMPONENT" "$VERSION_TYPE" "$PUBLISH_TARGET" "$TOKEN"
+      shell: bash
+      env:
+        COMPONENT: ${{ inputs.component }}
+        VERSION_TYPE: ${{ inputs.version-type }}
+        PUBLISH_TARGET: ${{ inputs.publish-target }}
+        TOKEN: ${{ inputs.token }}
+        MAVEN_USERNAME: ${{ inputs.maven-central-username }}
+        MAVEN_PASSWORD: ${{ inputs.maven-central-password }}
+
+    - name: Set up JDK
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 #v5.2.0
+      with:
+        java-version: ${{ inputs.java-version }}
+        distribution: "temurin"
+        server-id: "${{ inputs.publish-target == 'central' && 'central' || 'github' }}"
+        server-username: MAVEN_USERNAME
+        server-password: MAVEN_PASSWORD
+        gpg-private-key: ${{ inputs.gpg-private-key }}
+        gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+    - name: Set up Maven
+      if: ${{ inputs.maven-version != '' }}
+      uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1
+      with:
+        maven-version: ${{ inputs.maven-version }}
+
+    - name: Checkout monorepo
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+      with:
+        ref: ${{ inputs.ref }}
+        token: ${{ inputs.token }}
+        persist-credentials: true
+
+    - name: Cache Maven repository
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae #v5.0.5
+      with:
+        path: ~/.m2/repository
+        key: maven-monorepo-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
+        restore-keys: maven-monorepo-${{ runner.os }}-
+
+    - name: Validate Maven structure
+      run: |
+        . ${GITHUB_ACTION_PATH}/action-script.sh
+        validate_monorepo_structure "${{ inputs.component }}"
+      shell: bash
+
+    - name: Release component
+      id: release
+      run: |
+        . ${GITHUB_ACTION_PATH}/action-script.sh
+        release_component "$COMPONENT" "$VERSION_TYPE" "$PUBLISH_TARGET" "$DRY_RUN" \
+          "$MAVEN_PROFILE" "$MAVEN_ARGS" "$UPDATE_PARENT_VERSION"
+      shell: bash
+      env:
+        COMPONENT: ${{ inputs.component }}
+        VERSION_TYPE: ${{ inputs.version-type }}
+        PUBLISH_TARGET: ${{ inputs.publish-target }}
+        DRY_RUN: ${{ inputs.dry-run }}
+        MAVEN_PROFILE: ${{ inputs.maven-profile }}
+        MAVEN_ARGS: ${{ inputs.maven-args }}
+        UPDATE_PARENT_VERSION: ${{ inputs.update-parent-version }}
+        MAVEN_USERNAME: ${{ inputs.maven-central-username }}
+        MAVEN_PASSWORD: ${{ inputs.maven-central-password }}
+        MAVEN_GPG_PASSPHRASE: ${{ inputs.gpg-passphrase }}

--- a/actions/maven-monorepo-release/action.yaml
+++ b/actions/maven-monorepo-release/action.yaml
@@ -63,7 +63,7 @@ inputs:
     description: "Passphrase for GPG private key"
     required: false
     type: string
-  maven-central-username:
+  maven-username:
     description: "Maven Central (Sonatype) username for authentication"
     required: false
     type: string
@@ -114,8 +114,8 @@ runs:
         VERSION_TYPE: ${{ inputs.version-type }}
         PUBLISH_TARGET: ${{ inputs.publish-target }}
         TOKEN: ${{ inputs.token }}
-        MAVEN_USERNAME: ${{ inputs.maven-central-username }}
-        MAVEN_PASSWORD: ${{ inputs.maven-central-password }}
+        MAVEN_USERNAME: ${{ inputs.maven-username }}
+        MAVEN_PASSWORD: ${{ inputs.maven-password }}
 
     - name: Set up JDK
       uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 #v5.2.0
@@ -169,6 +169,6 @@ runs:
         MAVEN_PROFILE: ${{ inputs.maven-profile }}
         MAVEN_ARGS: ${{ inputs.maven-args }}
         UPDATE_PARENT_VERSION: ${{ inputs.update-parent-version }}
-        MAVEN_USERNAME: ${{ inputs.maven-central-username }}
-        MAVEN_PASSWORD: ${{ inputs.maven-central-password }}
+        MAVEN_USERNAME: ${{ inputs.maven-username }}
+        MAVEN_PASSWORD: ${{ inputs.maven-password }}
         MAVEN_GPG_PASSPHRASE: ${{ inputs.gpg-passphrase }}

--- a/actions/maven-monorepo-release/action.yaml
+++ b/actions/maven-monorepo-release/action.yaml
@@ -150,8 +150,10 @@ runs:
     - name: Validate Maven structure
       run: |
         . ${GITHUB_ACTION_PATH}/action-script.sh
-        validate_monorepo_structure "${{ inputs.component }}"
+        validate_monorepo_structure "$COMPONENT"
       shell: bash
+      env:
+        COMPONENT: ${{ inputs.component }}
 
     - name: Release component
       id: release

--- a/actions/maven-monorepo-release/action.yaml
+++ b/actions/maven-monorepo-release/action.yaml
@@ -67,7 +67,7 @@ inputs:
     description: "Maven Central (Sonatype) username for authentication"
     required: false
     type: string
-  maven-central-password:
+  maven-password:
     description: "Maven Central (Sonatype) password or authentication token"
     required: false
     type: string

--- a/actions/maven-monorepo-release/action.yaml
+++ b/actions/maven-monorepo-release/action.yaml
@@ -18,6 +18,12 @@ inputs:
     required: true
     type: string
     default: "patch"
+  version-property:
+    description: |
+      Optional: specify the version property to update (e.g., 'project.version' or 'my.component.version').
+      If not provided, defaults to the standard version element in the POM.
+    required: false
+    type: string
   ref:
     description: "Branch to create release from"
     required: false
@@ -164,6 +170,7 @@ runs:
       env:
         COMPONENT: ${{ inputs.component }}
         VERSION_TYPE: ${{ inputs.version-type }}
+        VERSION_PROPERTY: ${{ inputs.version-property }}
         PUBLISH_TARGET: ${{ inputs.publish-target }}
         DRY_RUN: ${{ inputs.dry-run }}
         MAVEN_PROFILE: ${{ inputs.maven-profile }}

--- a/actions/maven-monorepo-release/action.yaml
+++ b/actions/maven-monorepo-release/action.yaml
@@ -140,13 +140,6 @@ runs:
       with:
         maven-version: ${{ inputs.maven-version }}
 
-    - name: Checkout monorepo
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
-      with:
-        ref: ${{ inputs.ref }}
-        token: ${{ inputs.token }}
-        persist-credentials: true
-
     - name: Cache Maven repository
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae #v5.0.5
       with:

--- a/docs/actions-workflows-catalog.md
+++ b/docs/actions-workflows-catalog.md
@@ -29,6 +29,7 @@ Always check that document before modifying or depending on a deprecated compone
 | [docker-config-resolver](../actions/docker-config-resolver/README.md)           | Resolve `.qubership/docker.cfg` into a flat JSON config for the docker-action matrix   |
 | [ghcr-discover-repo-packages](../actions/ghcr-discover-repo-packages/README.md) | Discover GHCR container packages owned by a repository and return them as JSON         |
 | [k8s-hardening-scan](../actions/k8s-hardening-scan/README.md)                   | Validate Kubernetes hardening compliance with Kubescape (and optionally Trivy)         |
+| [maven-monorepo-release](../actions/maven-monorepo-release/README.md)           | Release Maven components from a monorepo with independent versioning per component      |
 | [maven-release](../actions/maven-release/README.md)                             | Release a Maven artifact (version bump, GPG sign, deploy) — dry-run by default         |
 | [maven-snapshot-deploy](../actions/maven-snapshot-deploy/README.md)             | Deploy Maven SNAPSHOT artifacts to Maven Central or GitHub Packages                    |
 | [metadata-action](../actions/metadata-action/README.md)                         | Render version strings and tags from per-branch/per-tag templates using GitHub context |

--- a/docs/monorepo-setup-guide.md
+++ b/docs/monorepo-setup-guide.md
@@ -638,26 +638,26 @@ mvn clean deploy
    # Release: 1.0.1 (patch), 1.1.0 (minor), or 2.0.0 (major)
    ```
 
-3. **Update version in pom.xml**
+2. **Update version in pom.xml**
 
    ```bash
    cd my-lib-1
    mvn versions:set -DnewVersion=1.0.1 -DgenerateBackupPoms=false
    ```
 
-4. **Build and test**
+3. **Build and test**
 
    ```bash
    mvn clean package
    ```
 
-5. **Deploy**
+4. **Deploy**
 
    ```bash
    mvn deploy -Prelease
    ```
 
-6. **Commit and tag**
+5. **Commit and tag**
 
    ```bash
    git add my-lib-1/pom.xml
@@ -667,7 +667,7 @@ mvn clean deploy
    git push origin my-lib-1-1.0.1
    ```
 
-7. **Update to next SNAPSHOT**
+6. **Update to next SNAPSHOT**
 
    ```bash
    mvn versions:set -DnewVersion=1.0.2-SNAPSHOT -DgenerateBackupPoms=false
@@ -676,7 +676,7 @@ mvn clean deploy
    git push origin main
    ```
 
-8. **Update dependencies in other components** (if needed)
+7. **Update dependencies in other components** (if needed)
 
    ```bash
    cd my-app

--- a/docs/monorepo-setup-guide.md
+++ b/docs/monorepo-setup-guide.md
@@ -1,6 +1,7 @@
 # Maven Monorepo Setup Guide
 
-Complete guide for setting up and managing a Maven monorepo with independent component versioning, suitable for use with the `maven-monorepo-release` GitHub Action.
+Complete guide for setting up and managing a Maven monorepo with independent component versioning,
+suitable for use with the `maven-monorepo-release` GitHub Action.
 
 ---
 
@@ -23,7 +24,7 @@ Complete guide for setting up and managing a Maven monorepo with independent com
 
 Recommended directory layout:
 
-```
+```text
 my-monorepo/
 ├── .github/
 │   └── workflows/
@@ -82,6 +83,7 @@ All `pom.xml` files must follow these principles:
 ```
 
 ❌ **Wrong** - don't inherit version:
+
 ```xml
 <!-- This will cause issues with independent versioning -->
 <parent>
@@ -484,6 +486,7 @@ Each component is a Maven module with its own `pom.xml`.
 ### Local Build
 
 Build entire monorepo:
+
 ```bash
 # Build all components (from each component directory)
 cd my-lib-1 && mvn clean package
@@ -492,6 +495,7 @@ cd my-app && mvn clean package
 ```
 
 Or build specific component:
+
 ```bash
 cd my-app && mvn clean package -Pdevelopment
 ```
@@ -697,7 +701,7 @@ on:
         default: github
         options:
           - github
-          - maven-central
+          - central
           - both
 
 permissions:
@@ -709,7 +713,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Release Component
-        uses: netcracker/qubership-workflow-hub/actions/maven-monorepo-release@v1.0.0
+        uses: netcracker/qubership-workflow-hub/actions/maven-monorepo-release@cabbb90e9471163cfac84bd50ff0296b2803b44c  # v2.3.0
         with:
           component: ${{ inputs.component }}
           version-type: ${{ inputs.version }}
@@ -718,8 +722,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           gpg-passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-          maven-central-username: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          maven-central-password: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          maven-username: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          maven-password: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
           java-version: '21'
           maven-profile: release
 ```
@@ -740,9 +744,9 @@ jobs:
   <servers>
     <!-- Maven Central (Sonatype) -->
     <server>
-      <id>maven-central</id>
-      <username>${env.MAVEN_CENTRAL_USERNAME}</username>
-      <password>${env.MAVEN_CENTRAL_PASSWORD}</password>
+      <id>central</id>
+      <username>${env.MAVEN_USERNAME}</username>
+      <password>${env.MAVEN_PASSWORD}</password>
     </server>
 
     <!-- GitHub Packages -->

--- a/docs/monorepo-setup-guide.md
+++ b/docs/monorepo-setup-guide.md
@@ -58,6 +58,7 @@ my-monorepo/
 ```
 
 **Key principles:**
+
 - Each component is a **separate top-level directory** (not nested)
 - Each component has its **own `pom.xml`**
 - **Independent versioning**: Each component maintains its own version
@@ -263,6 +264,7 @@ The parent POM (`parent/pom.xml`) defines common settings for all modules.
 ### Key Parent POM Points
 
 ✅ **Do this:**
+
 - Define `<dependencyManagement>` with versions
 - Define `<pluginManagement>` with plugin configurations
 - Use `<properties>` for versions
@@ -270,6 +272,7 @@ The parent POM (`parent/pom.xml`) defines common settings for all modules.
 - Define distribution management URLs
 
 ❌ **Don't do this:**
+
 - Add actual `<dependencies>` (only use in `<dependencyManagement>`)
 - Don't define `<modules>` (not needed for independent versioning)
 - Don't include component code in parent (parent is POM-only)
@@ -503,6 +506,7 @@ cd my-app && mvn clean package -Pdevelopment
 ### Publishing to Maven Central
 
 Requires:
+
 1. Sonatype JIRA account
 2. GPG key (sign artifacts)
 3. Proper configuration in `pom.xml` and `settings.xml`
@@ -628,28 +632,33 @@ mvn clean deploy
 ### Manual Release Steps (what the GitHub Action automates)
 
 1. **Determine new version**
+
    ```bash
    # Current: 1.0.0-SNAPSHOT
    # Release: 1.0.1 (patch), 1.1.0 (minor), or 2.0.0 (major)
    ```
 
-2. **Update version in pom.xml**
+3. **Update version in pom.xml**
+
    ```bash
    cd my-lib-1
    mvn versions:set -DnewVersion=1.0.1 -DgenerateBackupPoms=false
    ```
 
-3. **Build and test**
+4. **Build and test**
+
    ```bash
    mvn clean package
    ```
 
-4. **Deploy**
+5. **Deploy**
+
    ```bash
    mvn deploy -Prelease
    ```
 
-5. **Commit and tag**
+6. **Commit and tag**
+
    ```bash
    git add my-lib-1/pom.xml
    git commit -m "chore(my-lib-1): release version 1.0.1"
@@ -658,7 +667,8 @@ mvn clean deploy
    git push origin my-lib-1-1.0.1
    ```
 
-6. **Update to next SNAPSHOT**
+7. **Update to next SNAPSHOT**
+
    ```bash
    mvn versions:set -DnewVersion=1.0.2-SNAPSHOT -DgenerateBackupPoms=false
    git add my-lib-1/pom.xml
@@ -666,7 +676,8 @@ mvn clean deploy
    git push origin main
    ```
 
-7. **Update dependencies in other components** (if needed)
+8. **Update dependencies in other components** (if needed)
+
    ```bash
    cd my-app
    mvn versions:use-dep-version -Dincludes="com.example:my-lib-1" \
@@ -827,6 +838,7 @@ permissions:
 ### Version Management
 
 ✅ **Do:**
+
 - Use semantic versioning: MAJOR.MINOR.PATCH (e.g., 1.2.3)
 - Keep -SNAPSHOT between releases
 - Version each component independently
@@ -834,6 +846,7 @@ permissions:
 - Document version changes
 
 ❌ **Don't:**
+
 - Inherit version from parent
 - Use custom version formats
 - Share versions between independent components
@@ -843,12 +856,14 @@ permissions:
 ### Dependency Management
 
 ✅ **Do:**
+
 - Use `<dependencyManagement>` in parent for version centralization
 - Use explicit versions in `<dependency>` of child modules
 - Use parent's BOM for downstream users
 - Update dependencies systematically when releasing
 
 ❌ **Don't:**
+
 - Use wildcard versions
 - Use version ranges (e.g., `[1.0,2.0)`)
 - Add circular dependencies
@@ -858,6 +873,7 @@ permissions:
 ### Git Workflow
 
 ✅ **Do:**
+
 - Create semantic tags: `component-name-version` (e.g., `my-lib-1.0.1`)
 - Commit changes per component
 - Use conventional commits: `chore(component): message`
@@ -865,6 +881,7 @@ permissions:
 - Keep history clean
 
 ❌ **Don't:**
+
 - Mix releases from multiple components in one commit
 - Create ambiguous tags
 - Rebase after release
@@ -873,6 +890,7 @@ permissions:
 ### Documentation
 
 ✅ **Do:**
+
 - Keep README.md in each component
 - Document dependencies and relationships
 - Include build instructions
@@ -880,6 +898,7 @@ permissions:
 - Document API changes
 
 ❌ **Don't:**
+
 - Leave code uncommented
 - Ignore breaking changes
 - Publish without docs
@@ -888,6 +907,7 @@ permissions:
 ### Testing & Quality
 
 ✅ **Do:**
+
 - Run full test suite before release
 - Use CI/CD to validate builds
 - Test releases in staging first
@@ -895,6 +915,7 @@ permissions:
 - Run integration tests
 
 ❌ **Don't:**
+
 - Skip tests for releases
 - Release untested code
 - Ignore deprecation warnings
@@ -907,23 +928,29 @@ permissions:
 ### Build issues
 
 **Problem**: `Cannot find parent: com.example:parent:1.0.0`
+
 - **Solution**: Ensure parent/pom.xml exists and version matches
 
 **Problem**: `Dependency cycle detected`
+
 - **Solution**: Check for circular dependencies, refactor components
 
 ### Publishing issues
 
 **Problem**: `Authentication failed for Maven Central`
+
 - **Solution**: Verify MAVEN_CENTRAL_USERNAME and _PASSWORD are correct
 
 **Problem**: `GPG signature verification failed`
+
 - **Solution**: Check GPG key is imported, passphrase is correct
 
 ### Version management issues
 
 **Problem**: `Versions plugin cannot update version`
+
 - **Solution**: Ensure pom.xml has valid `<version>` element
 
 **Problem**: SNAPSHOT version not updating
+
 - **Solution**: Check versions:set plugin is working correctly, verify file permissions

--- a/docs/monorepo-setup-guide.md
+++ b/docs/monorepo-setup-guide.md
@@ -1,0 +1,925 @@
+# Maven Monorepo Setup Guide
+
+Complete guide for setting up and managing a Maven monorepo with independent component versioning, suitable for use with the `maven-monorepo-release` GitHub Action.
+
+---
+
+## Table of Contents
+
+1. [Monorepo Structure](#monorepo-structure)
+2. [POM Configuration](#pom-configuration)
+3. [Parent POM Setup](#parent-pom-setup)
+4. [BOM (Bill of Materials)](#bom-bill-of-materials)
+5. [Component Modules](#component-modules)
+6. [Build and Publishing](#build-and-publishing)
+7. [Release Workflow](#release-workflow)
+8. [Maven Configuration](#maven-configuration)
+9. [GitHub Actions Integration](#github-actions-integration)
+10. [Best Practices](#best-practices)
+
+---
+
+## Monorepo Structure
+
+Recommended directory layout:
+
+```
+my-monorepo/
+├── .github/
+│   └── workflows/
+│       └── release.yml              # Release workflow
+├── parent/
+│   ├── pom.xml
+│   └── README.md
+├── bom/
+│   ├── pom.xml
+│   └── README.md
+├── my-lib-1/
+│   ├── pom.xml
+│   ├── src/
+│   │   ├── main/
+│   │   └── test/
+│   └── README.md
+├── my-lib-2/
+│   ├── pom.xml
+│   ├── src/
+│   │   ├── main/
+│   │   └── test/
+│   └── README.md
+├── my-app/
+│   ├── pom.xml
+│   ├── src/
+│   │   ├── main/
+│   │   └── test/
+│   └── README.md
+├── pom.xml                         # Root aggregator (optional)
+└── README.md
+```
+
+**Key principles:**
+- Each component is a **separate top-level directory** (not nested)
+- Each component has its **own `pom.xml`**
+- **Independent versioning**: Each component maintains its own version
+- Components can depend on other components in the monorepo
+
+---
+
+## POM Configuration
+
+### Basic POM Requirements
+
+All `pom.xml` files must follow these principles:
+
+#### 1. Always declare explicit version
+
+```xml
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>my-component</artifactId>
+  <version>1.0.0</version>  <!-- ← REQUIRED: explicit version for all components -->
+</project>
+```
+
+❌ **Wrong** - don't inherit version:
+```xml
+<!-- This will cause issues with independent versioning -->
+<parent>
+  <version>${project.parent.version}</version>
+</parent>
+```
+
+#### 2. Explicitly list packaging
+
+```xml
+<packaging>jar</packaging>  <!-- or: pom, war, ear, etc. -->
+```
+
+#### 3. Include coordinates in manifest
+
+```xml
+<properties>
+  <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  <maven.compiler.source>11</maven.compiler.source>
+  <maven.compiler.target>11</maven.compiler.target>
+</properties>
+
+<build>
+  <plugins>
+    <plugin>
+      <groupId>org.apache.maven.plugins</groupId>
+      <artifactId>maven-jar-plugin</artifactId>
+      <version>3.3.0</version>
+      <configuration>
+        <archive>
+          <manifest>
+            <addBuildProperties>true</addBuildProperties>
+            <addClassPath>true</addClassPath>
+          </manifest>
+          <manifestEntries>
+            <Implementation-Title>${project.artifactId}</Implementation-Title>
+            <Implementation-Version>${project.version}</Implementation-Version>
+          </manifestEntries>
+        </archive>
+      </configuration>
+    </plugin>
+  </plugins>
+</build>
+```
+
+---
+
+## Parent POM Setup
+
+The parent POM (`parent/pom.xml`) defines common settings for all modules.
+
+### Minimal Parent POM
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.example</groupId>
+  <artifactId>parent</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+
+  <name>My Monorepo Parent</name>
+  <description>Parent POM for all components</description>
+  <url>https://github.com/example/my-monorepo</url>
+
+  <licenses>
+    <license>
+      <name>Apache License 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <id>team</id>
+      <name>Development Team</name>
+      <email>dev@example.com</email>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:https://github.com/example/my-monorepo.git</connection>
+    <url>https://github.com/example/my-monorepo</url>
+  </scm>
+
+  <!-- Define common properties for all modules -->
+  <properties>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+    <!-- Dependency versions -->
+    <junit.version>4.13.2</junit.version>
+    <slf4j.version>1.7.36</slf4j.version>
+  </properties>
+
+  <!-- Define common dependency versions (not as dependencies, but for reference) -->
+  <dependencyManagement>
+    <dependencies>
+      <!-- Internal components -->
+      <dependency>
+        <groupId>com.example</groupId>
+        <artifactId>my-lib-1</artifactId>
+        <version>1.0.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.example</groupId>
+        <artifactId>my-lib-2</artifactId>
+        <version>1.0.0</version>
+      </dependency>
+
+      <!-- External dependencies -->
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>${junit.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <!-- Common build plugins -->
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.11.0</version>
+          <configuration>
+            <source>${maven.compiler.source}</source>
+            <target>${maven.compiler.target}</target>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>3.0.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.3.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+  <!-- Distribution management (for publishing) -->
+  <distributionManagement>
+    <repository>
+      <id>central</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+    <snapshotRepository>
+      <id>central</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <repository>
+      <id>github</id>
+      <name>GitHub Packages</name>
+      <url>https://maven.pkg.github.com/example/my-monorepo</url>
+    </repository>
+  </distributionManagement>
+</project>
+```
+
+### Key Parent POM Points
+
+✅ **Do this:**
+- Define `<dependencyManagement>` with versions
+- Define `<pluginManagement>` with plugin configurations
+- Use `<properties>` for versions
+- Set compiler and encoding in `<properties>`
+- Define distribution management URLs
+
+❌ **Don't do this:**
+- Add actual `<dependencies>` (only use in `<dependencyManagement>`)
+- Don't define `<modules>` (not needed for independent versioning)
+- Don't include component code in parent (parent is POM-only)
+
+---
+
+## BOM (Bill of Materials)
+
+A BOM component defines a set of dependency versions for downstream projects.
+
+### BOM POM
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.example</groupId>
+  <artifactId>bom</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+
+  <name>My Monorepo BOM</name>
+  <description>Bill of Materials for all components</description>
+
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0.0</version>
+  </parent>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- Internal components -->
+      <dependency>
+        <groupId>com.example</groupId>
+        <artifactId>my-lib-1</artifactId>
+        <version>1.0.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.example</groupId>
+        <artifactId>my-lib-2</artifactId>
+        <version>1.0.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.example</groupId>
+        <artifactId>my-app</artifactId>
+        <version>1.0.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>
+```
+
+### Using the BOM
+
+Downstream projects import the BOM:
+
+```xml
+<dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>bom</artifactId>
+      <version>1.0.0</version>
+      <type>pom</type>
+      <scope>import</scope>
+    </dependency>
+  </dependencyManagement>
+
+<dependencies>
+  <!-- No version needed, inherited from BOM -->
+  <dependency>
+    <groupId>com.example</groupId>
+    <artifactId>my-lib-1</artifactId>
+  </dependency>
+</dependencies>
+```
+
+---
+
+## Component Modules
+
+Each component is a Maven module with its own `pom.xml`.
+
+### Library Component (my-lib-1)
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <!-- Explicit coordinates (not inherited) -->
+  <groupId>com.example</groupId>
+  <artifactId>my-lib-1</artifactId>
+  <version>1.0.0</version>
+  <packaging>jar</packaging>
+
+  <name>My Library 1</name>
+  <description>A library component</description>
+
+  <!-- Inherit configuration from parent -->
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0.0</version>
+  </parent>
+
+  <dependencies>
+    <!-- Use version from parent's dependencyManagement -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+```
+
+### Application Component (my-app)
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.example</groupId>
+  <artifactId>my-app</artifactId>
+  <version>1.0.0</version>
+  <packaging>jar</packaging>
+
+  <name>My Application</name>
+
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0.0</version>
+  </parent>
+
+  <!-- Depend on other monorepo components -->
+  <dependencies>
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>my-lib-1</artifactId>
+      <version>1.0.0</version>  <!-- Must be explicit -->
+    </dependency>
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>my-lib-2</artifactId>
+      <version>1.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.4.2</version>
+        <configuration>
+          <archive>
+            <manifest>
+              <mainClass>com.example.app.Main</mainClass>
+            </manifest>
+          </archive>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+          <finalName>my-app</finalName>
+          <appendAssemblyId>false</appendAssemblyId>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+```
+
+---
+
+## Build and Publishing
+
+### Local Build
+
+Build entire monorepo:
+```bash
+# Build all components (from each component directory)
+cd my-lib-1 && mvn clean package
+cd my-lib-2 && mvn clean package
+cd my-app && mvn clean package
+```
+
+Or build specific component:
+```bash
+cd my-app && mvn clean package -Pdevelopment
+```
+
+### Publishing to Maven Central
+
+Requires:
+1. Sonatype JIRA account
+2. GPG key (sign artifacts)
+3. Proper configuration in `pom.xml` and `settings.xml`
+
+#### Release Profile
+
+Add to parent `pom.xml`:
+
+```xml
+<profiles>
+  <profile>
+    <id>release</id>
+    <build>
+      <plugins>
+        <!-- Sign artifacts -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>3.0.1</version>
+          <executions>
+            <execution>
+              <id>sign-artifacts</id>
+              <phase>verify</phase>
+              <goals>
+                <goal>sign</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <gpgArguments>
+              <arg>--pinentry-mode</arg>
+              <arg>loopback</arg>
+            </gpgArguments>
+          </configuration>
+        </plugin>
+
+        <!-- Generate Javadoc -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>3.4.1</version>
+          <executions>
+            <execution>
+              <id>attach-javadocs</id>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+
+        <!-- Generate sources JAR -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>3.2.1</version>
+          <executions>
+            <execution>
+              <id>attach-sources</id>
+              <goals>
+                <goal>jar-no-fork</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </build>
+  </profile>
+</profiles>
+```
+
+#### Publish
+
+```bash
+cd my-lib-1
+mvn clean deploy -Prelease
+```
+
+### Publishing to GitHub Packages
+
+Add to parent `pom.xml`:
+
+```xml
+<distributionManagement>
+  <repository>
+    <id>github</id>
+    <name>GitHub Packages</name>
+    <url>https://maven.pkg.github.com/YOUR-ORG/YOUR-REPO</url>
+  </repository>
+  <snapshotRepository>
+    <id>github</id>
+    <name>GitHub Packages</name>
+    <url>https://maven.pkg.github.com/YOUR-ORG/YOUR-REPO</url>
+  </snapshotRepository>
+</distributionManagement>
+```
+
+Configure `~/.m2/settings.xml`:
+
+```xml
+<settings>
+  <servers>
+    <server>
+      <id>github</id>
+      <username>oauth2</username>
+      <password>YOUR_GITHUB_TOKEN</password>
+    </server>
+  </servers>
+</settings>
+```
+
+Publish:
+
+```bash
+cd my-lib-1
+mvn clean deploy
+```
+
+---
+
+## Release Workflow
+
+### Manual Release Steps (what the GitHub Action automates)
+
+1. **Determine new version**
+   ```bash
+   # Current: 1.0.0-SNAPSHOT
+   # Release: 1.0.1 (patch), 1.1.0 (minor), or 2.0.0 (major)
+   ```
+
+2. **Update version in pom.xml**
+   ```bash
+   cd my-lib-1
+   mvn versions:set -DnewVersion=1.0.1 -DgenerateBackupPoms=false
+   ```
+
+3. **Build and test**
+   ```bash
+   mvn clean package
+   ```
+
+4. **Deploy**
+   ```bash
+   mvn deploy -Prelease
+   ```
+
+5. **Commit and tag**
+   ```bash
+   git add my-lib-1/pom.xml
+   git commit -m "chore(my-lib-1): release version 1.0.1"
+   git tag my-lib-1-1.0.1
+   git push origin main
+   git push origin my-lib-1-1.0.1
+   ```
+
+6. **Update to next SNAPSHOT**
+   ```bash
+   mvn versions:set -DnewVersion=1.0.2-SNAPSHOT -DgenerateBackupPoms=false
+   git add my-lib-1/pom.xml
+   git commit -m "chore(my-lib-1): bump to next snapshot version 1.0.2-SNAPSHOT"
+   git push origin main
+   ```
+
+7. **Update dependencies in other components** (if needed)
+   ```bash
+   cd my-app
+   mvn versions:use-dep-version -Dincludes="com.example:my-lib-1" \
+       -DdepVersion="1.0.1" -DgenerateBackupPoms=false
+   git add my-app/pom.xml
+   git commit -m "chore(my-app): update my-lib-1 to 1.0.1"
+   git push origin main
+   ```
+
+### Automated Release with GitHub Action
+
+Create `.github/workflows/release.yml`:
+
+```yaml
+name: Release Component
+
+on:
+  workflow_dispatch:
+    inputs:
+      component:
+        description: 'Component to release'
+        required: true
+        type: string
+      version:
+        description: 'Version (major, minor, patch, or explicit like 1.2.3)'
+        required: true
+        type: string
+      publish-target:
+        description: 'Publish target'
+        required: true
+        type: choice
+        default: github
+        options:
+          - github
+          - maven-central
+          - both
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Release Component
+        uses: netcracker/qubership-workflow-hub/actions/maven-monorepo-release@v1.0.0
+        with:
+          component: ${{ inputs.component }}
+          version-type: ${{ inputs.version }}
+          publish-target: ${{ inputs.publish-target }}
+          dry-run: 'false'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          gpg-passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+          maven-central-username: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          maven-central-password: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          java-version: '21'
+          maven-profile: release
+```
+
+---
+
+## Maven Configuration
+
+### ~/.m2/settings.xml
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                              http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <servers>
+    <!-- Maven Central (Sonatype) -->
+    <server>
+      <id>maven-central</id>
+      <username>${env.MAVEN_CENTRAL_USERNAME}</username>
+      <password>${env.MAVEN_CENTRAL_PASSWORD}</password>
+    </server>
+
+    <!-- GitHub Packages -->
+    <server>
+      <id>github</id>
+      <username>oauth2</username>
+      <password>${env.GITHUB_TOKEN}</password>
+    </server>
+  </servers>
+
+  <profiles>
+    <!-- Release profile for signing and documentation -->
+    <profile>
+      <id>release</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <properties>
+        <gpg.executable>gpg</gpg.executable>
+        <gpg.passphrase>${env.MAVEN_GPG_PASSPHRASE}</gpg.passphrase>
+        <gpg.homedir>${env.GPG_HOMEDIR}</gpg.homedir>
+      </properties>
+    </profile>
+
+    <!-- Development profile (skip tests, javadoc, signing) -->
+    <profile>
+      <id>development</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <properties>
+        <maven.test.skip>true</maven.test.skip>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+      </properties>
+    </profile>
+  </profiles>
+
+  <activeProfiles>
+    <!-- Normally no profiles active -->
+  </activeProfiles>
+</settings>
+```
+
+---
+
+## GitHub Actions Integration
+
+### Required Secrets
+
+Create these secrets in GitHub (Settings → Secrets and variables → Actions):
+
+1. **MAVEN_GPG_PRIVATE_KEY**: Your GPG private key (armored)
+   ```bash
+   gpg --export-secret-keys --armor YOUR_KEY_ID | xclip -selection clipboard
+   ```
+
+2. **MAVEN_GPG_PASSPHRASE**: GPG key passphrase
+
+3. **MAVEN_CENTRAL_USERNAME**: Sonatype JIRA username
+
+4. **MAVEN_CENTRAL_PASSWORD**: Sonatype password/token
+
+### Required Permissions
+
+Workflow needs these permissions:
+
+```yaml
+permissions:
+  contents: write      # To create tags, commits
+  packages: write      # To publish to GitHub Packages
+  pull-requests: read  # Optional, for PR comments
+```
+
+---
+
+## Best Practices
+
+### Version Management
+
+✅ **Do:**
+- Use semantic versioning: MAJOR.MINOR.PATCH (e.g., 1.2.3)
+- Keep -SNAPSHOT between releases
+- Version each component independently
+- Update BOM when releasing parent
+- Document version changes
+
+❌ **Don't:**
+- Inherit version from parent
+- Use custom version formats
+- Share versions between independent components
+- Use @main for releases (use tags)
+- Commit without testing
+
+### Dependency Management
+
+✅ **Do:**
+- Use `<dependencyManagement>` in parent for version centralization
+- Use explicit versions in `<dependency>` of child modules
+- Use parent's BOM for downstream users
+- Update dependencies systematically when releasing
+
+❌ **Don't:**
+- Use wildcard versions
+- Use version ranges (e.g., `[1.0,2.0)`)
+- Add circular dependencies
+- Create tight coupling between components
+- Use LATEST or RELEASE versions
+
+### Git Workflow
+
+✅ **Do:**
+- Create semantic tags: `component-name-version` (e.g., `my-lib-1.0.1`)
+- Commit changes per component
+- Use conventional commits: `chore(component): message`
+- Include clear commit messages
+- Keep history clean
+
+❌ **Don't:**
+- Mix releases from multiple components in one commit
+- Create ambiguous tags
+- Rebase after release
+- Force-push to main
+
+### Documentation
+
+✅ **Do:**
+- Keep README.md in each component
+- Document dependencies and relationships
+- Include build instructions
+- Maintain CHANGELOG
+- Document API changes
+
+❌ **Don't:**
+- Leave code uncommented
+- Ignore breaking changes
+- Publish without docs
+- Use cryptic version numbers
+
+### Testing & Quality
+
+✅ **Do:**
+- Run full test suite before release
+- Use CI/CD to validate builds
+- Test releases in staging first
+- Verify dependencies resolve correctly
+- Run integration tests
+
+❌ **Don't:**
+- Skip tests for releases
+- Release untested code
+- Ignore deprecation warnings
+- Publish directly to Maven Central from CI without validation
+
+---
+
+## Troubleshooting
+
+### Build issues
+
+**Problem**: `Cannot find parent: com.example:parent:1.0.0`
+- **Solution**: Ensure parent/pom.xml exists and version matches
+
+**Problem**: `Dependency cycle detected`
+- **Solution**: Check for circular dependencies, refactor components
+
+### Publishing issues
+
+**Problem**: `Authentication failed for Maven Central`
+- **Solution**: Verify MAVEN_CENTRAL_USERNAME and _PASSWORD are correct
+
+**Problem**: `GPG signature verification failed`
+- **Solution**: Check GPG key is imported, passphrase is correct
+
+### Version management issues
+
+**Problem**: `Versions plugin cannot update version`
+- **Solution**: Ensure pom.xml has valid `<version>` element
+
+**Problem**: SNAPSHOT version not updating
+- **Solution**: Check versions:set plugin is working correctly, verify file permissions

--- a/docs/monorepo-setup-guide.md
+++ b/docs/monorepo-setup-guide.md
@@ -810,6 +810,7 @@ jobs:
 Create these secrets in GitHub (Settings → Secrets and variables → Actions):
 
 1. **MAVEN_GPG_PRIVATE_KEY**: Your GPG private key (armored)
+
    ```bash
    gpg --export-secret-keys --armor YOUR_KEY_ID | xclip -selection clipboard
    ```


### PR DESCRIPTION
## Summary

Adds a new `maven-monorepo-release` composite action that automates releasing individual Maven
components from a monorepo with independent versioning per component. Unlike `maven-release`
(which uses the Maven Release Plugin), this action implements custom version management via a
shell script to support independent component versioning, automatic intra-monorepo dependency
updates, and component-scoped git tags (`<component>-<version>`).

## Issue

#764

## Breaking Change?

- [ ] Yes
- [x] No

## Scope / Project

`actions/maven-monorepo-release`

## Implementation Notes

- Composite action backed by `action-script.sh` — handles version bump, build, deploy, git
  tagging, SNAPSHOT bump, and dependency propagation across the monorepo
- All inputs passed to shell via `env:` vars (template-injection fix applied during PR audit)
- Supports `publish-target: central | github | both`; GPG signing for Maven Central
- `dry-run: 'true'` (default) builds and deploys SNAPSHOT without version bump or tagging
- Optional `version-property` input to also update a named Maven property in dependent POMs
- Optional `skip-parent-check` to bypass parent POM inheritance validation
- Catalog updated (`docs/actions-workflows-catalog.md`) and CLAUDE.md action count bumped 23→24
- `docs/monorepo-setup-guide.md` included on branch — corrected `publish-target` option value
  (`maven-central` → `central`), old input names (`maven-central-username/password` →
  `maven-username/password`), action ref updated to current SHA

## Tests / Evidence

Dry-run validated locally. Action script and YAML reviewed against `action-script.sh` logic.
Markdownlint, EditorConfig, and zizmor security audit applied and clean.

## Additional Notes

None.