### PR TITLE
feat(actions/apm-packages-update): add auto-merge and PR options

### DIFF
--- a/actions/apm-packages-update/README.md
+++ b/actions/apm-packages-update/README.md
@@ -11,6 +11,8 @@ Updates APM-managed packages in the current repository and creates a pull reques
 - Runs `apm update --yes --target <target>` non-interactively via [microsoft/apm-action](https://github.com/microsoft/APM), using `apm.yml` by default and `target` as an override
 - Opens a pull request on branch `chore/update-apm-packages` with the resulting changes
 - Uses a dynamic PR title and body that include the resolved target, base branch, and workflow run link
+- Supports commit sign-off, requesting user/team reviewers, and a configurable branch-deletion policy on the created pull request
+- Optionally enables GitHub auto-merge on the created pull request with a configurable merge method (`merge`, `squash`, or `rebase`)
 - Reports the PR URL or "no changes" to the workflow job summary
 
 ## 📌 Inputs
@@ -21,6 +23,12 @@ Updates APM-managed packages in the current repository and creates a pull reques
 | `dry-run` | Run `apm update` in dry-run mode and skip pull request creation   | No       | `false`  |
 | `debug`  | Print runner and APM diagnostics before updating packages         | No       | `false`  |
 | `target` | Optional APM target override; accepts one target or a comma-separated list | No | `""` |
+| `auto-merge` | Automatically enable auto-merge for the created pull request. Has no effect in `dry-run` mode or when no pull request was created | No | `false` |
+| `merge-method` | Merge method to use for auto-merge; one of `merge`, `squash`, or `rebase` (case-insensitive). Ignored unless `auto-merge` is `true` | No | `squash` |
+| `delete-branch` | Automatically delete the `chore/update-apm-packages` branch after the pull request is merged | No | `true` |
+| `sign-off` | Sign off commits in the pull request | No | `false` |
+| `reviewers` | Comma-separated list of GitHub usernames to request review from | No | `""` |
+| `team-reviewers` | Comma-separated list of GitHub team slugs to request review from | No | `""` |
 | `token`  | GitHub token with permission to create branches and pull requests | Yes      | -        |
 
 ## How it works
@@ -35,9 +43,13 @@ Updates APM-managed packages in the current repository and creates a pull reques
 6. If `dry-run: true`, skips pull request creation after printing the update result.
 7. Otherwise creates or updates a PR on branch `chore/update-apm-packages` (base: `inputs.branch`).
   The PR title includes the resolved target, and the body includes the executed command,
-  base branch, workflow run link, and a short review checklist. The branch is deleted
-  automatically after merge.
-8. Logs the PR URL to the job summary, or reports "no changes" if nothing was updated.
+  base branch, workflow run link, and a short review checklist. Commit sign-off, requested
+  reviewers/team reviewers, and post-merge branch deletion are controlled by the `sign-off`,
+  `reviewers`, `team-reviewers`, and `delete-branch` inputs respectively.
+8. If `auto-merge: true` and a pull request was created (skipped in `dry-run` mode or when no
+  PR was opened), enables GitHub auto-merge on the PR using `merge-method`. The step fails if
+  `merge-method` is not `merge`, `squash`, or `rebase`.
+9. Logs the PR URL to the job summary, or reports "no changes" if nothing was updated.
 
 ## Usage
 
@@ -56,6 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
@@ -69,7 +82,7 @@ jobs:
           debug: "true"
           dry-run: "true"
           target: ""
-          token: ${{ secrets.APM_UPDATE_TOKEN }}
+          token: ${{ secrets.APM_UPDATE_TOKEN }}  # PAT with `repo` scope (+ `read:org` for team-reviewers)
 ```
 
 ## Notes
@@ -83,7 +96,13 @@ jobs:
   `peter-evans/create-pull-request` updates the existing PR rather than opening a new one.
 - The generated PR title is `chore(apm): update packages for <resolved-target>` and the body
   includes the resolved target, base branch, actor, and a link back to the originating workflow run.
-- The `token` input must have permission to push branches and open pull requests.
+- `auto-merge: true` only takes effect when a pull request was actually created (not in
+  `dry-run` mode) and requires the "Allow auto-merge" repository setting to be enabled;
+  merging itself still waits on required checks and reviews.
+- `merge-method` accepts `merge`, `squash`, or `rebase` (case-insensitive). Any other value
+  fails the "Enable auto-merge" step.
+- The `token` input must have permission to push branches and open pull requests. Using
+  `team-reviewers` additionally requires the token to read organization membership.
   The org-level secret `APM_UPDATE_TOKEN` is the recommended value.
 - Pin to a full 40-character commit SHA with the release tag as a trailing comment, e.g.
   `@cabbb90e9471163cfac84bd50ff0296b2803b44c # v2.3.0`. The SHA is the immutable pin;

--- a/actions/apm-packages-update/action.yml
+++ b/actions/apm-packages-update/action.yml
@@ -3,23 +3,47 @@ description: Updates APM-managed packages in the current repository and creates 
 
 inputs:
   branch:
-    description: Target branch to update
+    description: Target branch to update.
     required: false
     default: main
   dry-run:
-    description: Run APM update in dry-run mode and skip pull request creation
+    description: Run APM update in dry-run mode and skip pull request creation.
     required: false
     default: "false"
   debug:
-    description: Print runner and APM diagnostics before updating packages
+    description: Print runner and APM diagnostics before updating packages.
     required: false
     default: "false"
   target:
-    description: Optional APM target override; accepts a single target or comma-separated list
+    description: Optional APM target override; accepts a single target or comma-separated list.
+    required: false
+    default: ""
+  auto-merge:
+    description: Automatically enable auto-merge for the created pull request.
+    required: false
+    default: "false"
+  merge-method:
+    description: Merge method to use for auto-merge; valid values are 'merge', 'squash', or 'rebase'.
+    required: false
+    default: "squash"
+  delete-branch:
+    description: Automatically delete the branch after the pull request is merged.
+    required: false
+    default: "true"
+  sign-off:
+    description: Sign off commits in the pull request.
+    required: false
+    default: "false"
+  reviewers:
+    description: Comma-separated list of GitHub usernames to request review from.
+    required: false
+    default: ""
+  team-reviewers:
+    description: Comma-separated list of GitHub team slugs to request review from.
     required: false
     default: ""
   token:
-    description: GitHub token with permission to create branches and pull requests
+    description: GitHub token with permission to create branches and pull requests.
     required: true
 
 runs:
@@ -148,8 +172,11 @@ runs:
         token: ${{ inputs.token }}
         base: ${{ inputs.branch }}
         branch: chore/update-apm-packages
-        delete-branch: true
+        delete-branch: ${{ inputs.delete-branch }}
         title: "chore(apm): update packages for ${{ steps.resolve-target.outputs.target }}"
+        signoff: ${{ inputs.sign-off }}
+        reviewers: ${{ inputs.reviewers }}
+        team-reviewers: ${{ inputs.team-reviewers }}
         commit-message: "chore(apm): update packages for ${{ steps.resolve-target.outputs.target }}"
         body: |
           ## Summary
@@ -177,17 +204,41 @@ runs:
           - `apm.lock.yaml`
           - deployed APM files
 
+    - name: Enable auto-merge
+      if: ${{ inputs.dry-run != 'true' && inputs.auto-merge == 'true' && steps.create-pr.outputs.pull-request-number != '' }}
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
+        MERGE_METHOD: ${{ inputs.merge-method }}
+      run: |
+        set -eu
+        normalized_merge_method="${MERGE_METHOD,,}"
+        case "$normalized_merge_method" in
+          merge|squash|rebase)
+            ;;
+          *)
+            echo "Unsupported merge method '$MERGE_METHOD'. Expected one of: merge, squash, rebase"
+            exit 1
+            ;;
+        esac
+
+        gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --auto --"$normalized_merge_method"
+
     - name: Log result
       shell: bash
+      env:
+        DRY_RUN: ${{ inputs.dry-run }}
+        PR_URL: ${{ steps.create-pr.outputs.pull-request-url }}
       run: |
-        if [ "${{ inputs.dry-run }}" = "true" ]; then
+        if [ "$DRY_RUN" = "true" ]; then
           echo "Dry-run mode enabled, pull request creation skipped"
           echo "Dry-run mode enabled, pull request creation skipped" >> "$GITHUB_STEP_SUMMARY"
           exit 0
         fi
-        if [ "${{ steps.create-pr.outputs.pull-request-url }}" != "" ]; then
-          echo "::notice title=PR created::${{ steps.create-pr.outputs.pull-request-url }}"
-          echo "PR created: ${{ steps.create-pr.outputs.pull-request-url }}" >> "$GITHUB_STEP_SUMMARY"
+        if [ -n "$PR_URL" ]; then
+          echo "::notice title=PR created::${PR_URL}"
+          echo "PR created: ${PR_URL}" >> "$GITHUB_STEP_SUMMARY"
         else
           echo "No changes detected, PR not created"
           echo "No changes detected, PR not created" >> "$GITHUB_STEP_SUMMARY"

--- a/agent-packages/qubership-workflow-hub-usage/.apm/skills/qubership-actions-guide/utilities.md
+++ b/agent-packages/qubership-workflow-hub-usage/.apm/skills/qubership-actions-guide/utilities.md
@@ -105,15 +105,19 @@ schedule or manually.
 - `apm.yml` must exist at the repository root.
 - The specified `target` must be configured in `apm.yml` (the action adds it automatically
   if missing).
+- Enabling `auto-merge` requires the repository setting "Allow auto-merge" to be turned on;
+  the merge still waits on required checks and reviews.
 
 ### Permissions
 
 ```yaml
 permissions:
   contents: read
+  pull-requests: write
 ```
 
-The `token` input must have permission to push branches and open pull requests.
+The `token` input must have permission to push branches and open pull requests. Using
+`team-reviewers` additionally requires the token to read organization membership.
 Use the org-level secret `APM_UPDATE_TOKEN`.
 
 ### Inputs
@@ -122,6 +126,12 @@ Use the org-level secret `APM_UPDATE_TOKEN`.
 | --- | --- | --- | --- |
 | `branch` | No | `main` | Target branch to update |
 | `target` | No | `claude` | APM target name in `apm.yml` |
+| `auto-merge` | No | `false` | Enable GitHub auto-merge on the created PR; has no effect in `dry-run` mode or when no PR is opened |
+| `merge-method` | No | `squash` | `merge`, `squash`, or `rebase`; used only when `auto-merge` is `true` |
+| `delete-branch` | No | `true` | Delete the `chore/update-apm-packages` branch after the PR is merged |
+| `sign-off` | No | `false` | Sign off commits on the created PR |
+| `reviewers` | No | `""` | Comma-separated GitHub usernames to request review from |
+| `team-reviewers` | No | `""` | Comma-separated GitHub team slugs to request review from |
 | `token` | Yes | — | Use `secrets.APM_UPDATE_TOKEN` |
 
 ### Usage pattern
@@ -139,11 +149,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: write
     steps:
       - name: Update APM packages
         uses: netcracker/qubership-workflow-hub/actions/apm-packages-update@<resolved-sha>  # <resolved-tag>
         with:
-          token: ${{ secrets.APM_UPDATE_TOKEN }}
+          token: ${{ secrets.APM_UPDATE_TOKEN }}  # PAT with `repo` scope (+ `read:org` for team-reviewers)
 ```
 
 ---


### PR DESCRIPTION
## Summary
Adds an optional `auto-merge` input to `apm-packages-update` that enables GitHub auto-merge
on the created PR once required checks pass, using a configurable `merge-method`
(merge/squash/rebase). Also adds `delete-branch`, `sign-off`, `reviewers`, and
`team-reviewers` inputs for finer control over the generated pull request.

## Issue
Closes #907

## Breaking Change?
- [ ] Yes
- [x] No

All new inputs are optional with backward-compatible defaults (`auto-merge: false`,
`delete-branch: true` preserves the prior hardcoded behavior).

## Scope / Project
`actions/apm-packages-update`

## Implementation Notes
- New "Enable auto-merge" step runs after PR creation, gated on
  `dry-run != 'true' && auto-merge == 'true' && create-pr.outputs.pull-request-number != ''`;
  validates `merge-method` against `merge`/`squash`/`rebase` (case-insensitive) before calling
  `gh pr merge --auto`.
- `delete-branch` is now driven by the new input instead of being hardcoded to `true`.
- `sign-off`, `reviewers`, and `team-reviewers` are passed straight through to
  `peter-evans/create-pull-request`.
- Fixed a zizmor `template-injection` finding in "Log result" by passing `inputs.dry-run` and
  `steps.create-pr.outputs.pull-request-url` through `env:` instead of interpolating them
  directly in the `run:` block.
- Updated `actions/apm-packages-update/README.md` (inputs table, Features, How it works,
  Notes, permissions in the usage example) and the APM skill guide
  (`agent-packages/qubership-workflow-hub-usage/.apm/skills/qubership-actions-guide/utilities.md`)
  to match.

## Tests / Evidence
- Ran the zizmor, EditorConfig, and markdown-rules audits against all changed files — no
  violations found.
- Verified both `uses:` pins (`microsoft/apm-action@v1.9.1`,
  `peter-evans/create-pull-request@v8.1.1`) resolve to the commit SHAs pinned in the file via
  the GitHub API.
- No automated tests exist for this composite action; no live dry-run was performed against a
  real repository.

## Additional Notes
Per the issue, `auto-merge` defaults to `false`. Repositories must have branch
protection/merge rulesets configured before enabling it — otherwise the PR can merge without
any required checks.