### PR TITLE
feat(docker-action): add cache inputs and JSON build-args support

### DIFF
--- a/actions/docker-action/README.md
+++ b/actions/docker-action/README.md
@@ -351,7 +351,9 @@ jobs:
   Avoid placing secrets directly in `ARG` / `ENV` instructions in the Dockerfile — use
   `--secret` mounts or build-time secrets instead.
 - Always pin to `@v2.2.1` or a specific SHA — never `@main` in production.
-- Full documentation of `cache-from` and `cache-to` inputs can be found on [docker/build-push-action page](https://github.com/docker/build-push-action)
+- Full documentation of `cache-from` and `cache-to` inputs can be found on the
+  [docker/build-push-action page](https://github.com/docker/build-push-action).
+
 ---
 
 ## Troubleshooting

--- a/actions/docker-action/README.md
+++ b/actions/docker-action/README.md
@@ -29,28 +29,30 @@ and produces a signed metadata JSON artifact after a successful push.
 
 | Name                               | Description                                                                                                | Required | Default                                                                     |
 | ---------------------------------- | ---------------------------------------------------------------------------------------------------------- | -------- | --------------------------------------------------------------------------- |
-| `ref`                              | Git ref (branch, tag, or SHA) to checkout. Ignored when `checkout` is `false`.                             | No       | `""`                                                                        |
-| `custom-image-name`                | Override for the Docker image name. If not set, derived from component name or repository name.            | No       | `""`                                                                        |
-| `context`                          | Context mode for `docker/metadata-action`: `git` reads metadata from git history, `workflow` reads it from the workflow event payload. Affects auto-generated tags. | No       | `"git"`                                                                     |
-| `dry-run`                          | Build without pushing. Skips registry login validation, push, and metadata upload.                         | No       | `"false"`                                                                   |
-| `download-artifact`                | Download a workflow artifact before the build.                                                             | No       | `"false"`                                                                   |
-| `component`                        | Component descriptor in JSON format. Accepts an object or a single-element array.                          | No       | `[{"name": "default", "dockerfile": "./Dockerfile", "build_context": "."}]` |
-| `platforms`                        | Target platforms for the build (comma-separated, e.g. `linux/amd64,linux/arm64`).                          | No       | `"linux/amd64"`                                                             |
-| `tags`                             | Comma-separated image tags. If empty, tags are auto-generated from branch/semver/PR metadata.              | No       | `""`                                                                        |
-| `download-artifact-name`           | Name of the artifact to download. Mutually exclusive with `download-artifact-ids`.                         | No       | `""`                                                                        |
-| `download-artifact-ids`            | Comma-separated artifact IDs to download. Mutually exclusive with `download-artifact-name`.                | No       | `""`                                                                        |
-| `download-artifact-path`           | Destination path for downloaded artifacts. Defaults to `$GITHUB_WORKSPACE`.                                | No       | `""`                                                                        |
-| `download-artifact-pattern`        | Glob pattern for artifacts to download. Ignored if `download-artifact-name` is set.                        | No       | `""`                                                                        |
-| `download-artifact-merge-multiple` | Unpack multiple artifacts into a single directory (`true`) or separate directories (`false`).              | No       | `"false"`                                                                   |
-| `sbom`                             | Enable SBOM (Software Bill of Materials) generation.                                                       | No       | `"false"`                                                                   |
 | `build-args`                       | Build arguments for Docker. Supports comma-separated or newline-delimited format.                          | No       | `""`                                                                        |
-| `checkout`                         | Checkout the repository before the build. Set to `false` when the calling workflow already checked out the repo. | No       | `"true"`                                                                    |
-| `registry`                         | Target registry: `ghcr.io`, `docker.io`, or `ghcr.io,docker.io` for both.                                  | No       | `"ghcr.io"`                                                                 |
+| `cache-from`                       | List of external cache sources for buildx (e.g., user/app:cache, type=local,src=path/to/dir)               | No       | `""`                                                                        |
+| `cache-to`                         | List of cache export destinations for buildx (e.g., user/app:cache, type=local,dest=path/to/dir)           | No       | `""`                                                                        |
+| `checkout`                         | Checkout the repository before the build. Set to `false` when the calling workflow already checked out the repo. | No | `"true"`                                                                    |
+| `component`                        | Component descriptor in JSON format. Accepts an object or a single-element array.                          | No       | `[{"name": "default", "dockerfile": "./Dockerfile", "build_context": "."}]` |
+| `context`                          | Context mode for `docker/metadata-action`: `git` reads metadata from git history, `workflow` reads it from the workflow event payload. Affects auto-generated tags. | No       |`"git"`             |
+| `custom-image-name`                | Override for the Docker image name. If not set, derived from component name or repository name.            | No       | `""`                                                                        |
 | `docker-io-login`                  | Username for Docker Hub login. Required when `registry` contains `docker.io` and `dry-run` is `false`.     | No       | -                                                                           |
 | `docker-io-token`                  | Access token for Docker Hub login. Required when `registry` contains `docker.io` and `dry-run` is `false`. | No       | -                                                                           |
-| `skip-qemu-buildx`                 | **Deprecated.** Use `setup-qemu` and `setup-buildx` instead. Skips both QEMU and Buildx setup when `true`. | No       | `"false"`                                                                   |
-| `setup-qemu`                       | Set up QEMU for multi-platform builds.                                                                     | No       | `"true"`                                                                    |
+| `download-artifact`                | Download a workflow artifact before the build.                                                             | No       | `"false"`                                                                   |
+| `download-artifact-ids`            | Comma-separated artifact IDs to download. Mutually exclusive with `download-artifact-name`.                | No       | `""`                                                                        |
+| `download-artifact-merge-multiple` | Unpack multiple artifacts into a single directory (`true`) or separate directories (`false`).              | No       | `"false"`                                                                   |
+| `download-artifact-name`           | Name of the artifact to download. Mutually exclusive with `download-artifact-ids`.                         | No       | `""`                                                                        |
+| `download-artifact-path`           | Destination path for downloaded artifacts. Defaults to `$GITHUB_WORKSPACE`.                                | No       | `""`                                                                        |
+| `download-artifact-pattern`        | Glob pattern for artifacts to download. Ignored if `download-artifact-name` is set.                        | No       | `""`                                                                        |
+| `dry-run`                          | Build without pushing. Skips registry login validation, push, and metadata upload.                         | No       | `"false"`                                                                   |
+| `platforms`                        | Target platforms for the build (comma-separated, e.g. `linux/amd64,linux/arm64`).                          | No       | `"linux/amd64"`                                                             |
+| `ref`                              | Git ref (branch, tag, or SHA) to checkout. Ignored when `checkout` is `false`.                             | No       | `""`                                                                        |
+| `registry`                         | Target registry: `ghcr.io`, `docker.io`, or `ghcr.io,docker.io` for both.                                  | No       | `"ghcr.io"`                                                                 |
+| `sbom`                             | Enable SBOM (Software Bill of Materials) generation.                                                       | No       | `"false"`                                                                   |
 | `setup-buildx`                     | Set up Docker Buildx.                                                                                      | No       | `"true"`                                                                    |
+| `setup-qemu`                       | Set up QEMU for multi-platform builds.                                                                     | No       | `"true"`                                                                    |
+| `skip-qemu-buildx`                 | **Deprecated.** Use `setup-qemu` and `setup-buildx` instead. Skips both QEMU and Buildx setup when `true`. | No       | `"false"`                                                                   |
+| `tags`                             | Comma-separated image tags. If empty, tags are auto-generated from branch/semver/PR metadata.              | No       | `""`                                                                        |
 
 ---
 
@@ -132,17 +134,17 @@ Place the `permissions` block at the **job level**, not the workflow level.
 
 The `component` input accepts either a JSON object or a single-element array. Fields:
 
-| Field           | Description                                  | Default          |
-| --------------- | -------------------------------------------- | ---------------- |
-| `name`          | Component name — used for image naming       | `"default"`      |
-| `dockerfile`    | Path to the Dockerfile                       | `"./Dockerfile"` |
-| `build_context` | Docker build context path                    | `"."`            |
-| `arguments`     | Build arguments (comma-separated or newline) | `""`             |
+| Field                       | Description                                                     | Default          |
+| --------------------------- | --------------------------------------------------------------- | ---------------- |
+| `name`                      | Component name — used for image naming                          | `"default"`      |
+| `dockerfile`                | Path to the Dockerfile                                          | `"./Dockerfile"` |
+| `build_context`             | Docker build context path                                       | `"."`            |
+| `arguments` or `build_args` | Build arguments (comma-separated or newline or JSON dictionary) | `""`             |
 
 Deprecated field aliases still accepted for compatibility: `file` → `dockerfile`,
 `context` → `build_context`.
 
-**Example:**
+**Example (comma-separated arguments):**
 
 ```yaml
 with:
@@ -153,6 +155,25 @@ with:
         "dockerfile": "./docker/Dockerfile.prod",
         "build_context": "./src",
         "arguments": "NODE_ENV=production,DEBUG=false"
+      }
+    ]
+```
+
+**Example (JSON dictionary arguments):**
+
+```yaml
+with:
+  component: |
+    [
+      {
+        "name": "my-service",
+        "dockerfile": "./docker/Dockerfile.prod",
+        "build_context": "./src",
+        "arguments":
+          {
+            "NODE_ENV": "production",
+            "DEBUG": "false"
+          }
       }
     ]
 ```
@@ -309,6 +330,8 @@ jobs:
             BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
           setup-qemu: false
           setup-buildx: false
+          cache-from: type=gha,scope=my-custom-image
+          cache-to: type=gha,mode=max,scope=my-custom-image
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -328,7 +351,7 @@ jobs:
   Avoid placing secrets directly in `ARG` / `ENV` instructions in the Dockerfile — use
   `--secret` mounts or build-time secrets instead.
 - Always pin to `@v2.2.1` or a specific SHA — never `@main` in production.
-
+- Full documentation of `cache-from` and `cache-to` inputs can be found on [docker/build-push-action page](https://github.com/docker/build-push-action)
 ---
 
 ## Troubleshooting

--- a/actions/docker-action/README.md
+++ b/actions/docker-action/README.md
@@ -139,10 +139,10 @@ The `component` input accepts either a JSON object or a single-element array. Fi
 | `name`                      | Component name — used for image naming                          | `"default"`      |
 | `dockerfile`                | Path to the Dockerfile                                          | `"./Dockerfile"` |
 | `build_context`             | Docker build context path                                       | `"."`            |
-| `arguments` or `build_args` | Build arguments (comma-separated or newline or JSON dictionary) | `""`             |
+| `build_args`                | Build arguments (comma-separated or newline or JSON dictionary) | `""`             |
 
 Deprecated field aliases still accepted for compatibility: `file` → `dockerfile`,
-`context` → `build_context`.
+`context` → `build_context`, `arguments` → `build_args`.
 
 **Example (comma-separated arguments):**
 
@@ -154,7 +154,7 @@ with:
         "name": "my-service",
         "dockerfile": "./docker/Dockerfile.prod",
         "build_context": "./src",
-        "arguments": "NODE_ENV=production,DEBUG=false"
+        "build_args": "NODE_ENV=production,DEBUG=false"
       }
     ]
 ```
@@ -169,7 +169,7 @@ with:
         "name": "my-service",
         "dockerfile": "./docker/Dockerfile.prod",
         "build_context": "./src",
-        "arguments":
+        "build_args":
           {
             "NODE_ENV": "production",
             "DEBUG": "false"

--- a/actions/docker-action/action.yml
+++ b/actions/docker-action/action.yml
@@ -87,6 +87,12 @@ inputs:
     description: "Setup Docker Buildx."
     required: false
     default: "true"
+  cache-from:
+    description: "Cache sources for the build."
+    required: false
+  cache-to:
+    description: "Cache destinations for the build."
+    required: false
 
 outputs:
   image-name:
@@ -156,7 +162,14 @@ runs:
         component_name=$(echo "$component_from_json" | jq -r '.name // "default"')
         component_file=$(echo "$component_from_json" | jq -r '.dockerfile // .file // "./Dockerfile"')
         component_context=$(echo "$component_from_json" | jq -r '.build_context // .context // "."')
-        component_build_args=$(echo "$component_from_json" | jq -r '.arguments // empty')
+        component_build_args_raw=$(echo "$component_from_json" | jq -c '.arguments // .build_args // empty')
+
+        # Convert a JSON object of build args (e.g. {"key1":"value1"}) to key=value pairs
+        if [ -n "$component_build_args_raw" ] && [ "$(echo "$component_build_args_raw" | jq -r 'type')" == "object" ]; then
+          component_build_args=$(echo "$component_build_args_raw" | jq -r 'to_entries | map("\(.key)=\(.value)") | join(",")')
+        else
+          component_build_args=$(echo "$component_from_json" | jq -r '.arguments // .build_args // empty')
+        fi
 
         # Convert comma-separated build args to newline-separated
         if [ -n "$component_build_args" ] && [[ "$component_build_args" == *","* ]]; then
@@ -308,6 +321,8 @@ runs:
         PLATFORMS_INPUT: ${{ inputs.platforms }}
         GHCR_URL: ${{ env.GHCR_URL }}
         DOCKER_URL: ${{ env.DOCKER_URL }}
+        CACHE_FROM: ${{ inputs.cache-from }}
+        CACHE_TO: ${{ inputs.cache-to }}
       run: |
         set -euo pipefail
 
@@ -408,6 +423,8 @@ runs:
         labels: ${{ env.FINAL_LABELS }}
         platforms: ${{ env.FINAL_PLATFORMS }}
         build-args: ${{ env.FINAL_BUILD_ARGS }}
+        cache-from: ${{ env.CACHE_FROM }}
+        cache-to: ${{ env.CACHE_TO }}
 
     - name: Output result
       if: ${{ ! (inputs.dry-run == 'true') }}


### PR DESCRIPTION
# Pull Request

## Summary
Adds `cache-from` and `cache-to` inputs to `docker-action` to expose Buildx cache import/export
(e.g. GitHub Actions cache via `type=gha`) to `docker/build-push-action`. Also extends the
`component` descriptor's build-args field to accept a JSON object (`{"KEY": "value"}`) in
addition to the existing comma/newline-delimited string format, and renames the field from
`arguments` to `build_args` for consistency with `build-args`/`BUILD_ARGS_INPUT` naming
elsewhere in the action (the old `arguments` key is kept as a deprecated alias).

## Issue
Related to #911. No explicit `Fixes`/`Closes` keyword in the commit history — no issue is
auto-closed by this PR.

## Breaking Change?
- [ ] Yes
- [x] No

`build_args` is additive alongside the deprecated `arguments` alias, which is still accepted.
`cache-from`/`cache-to` are new optional inputs with no default, so existing callers are
unaffected.

## Scope / Project
`actions/docker-action`

## Implementation Notes
- `cache-from`/`cache-to` inputs are passed through a step-level `env:` block
  (`CACHE_FROM`/`CACHE_TO`) into `docker/build-push-action`'s `cache-from`/`cache-to` fields.
- `component.build_args` accepts a JSON object; when detected (`jq 'type' == "object"`) it is
  converted to comma-separated `key=value` pairs before the existing comma→newline conversion
  logic runs.
- Field resolution order is `component.arguments // component.build_args` for backward
  compatibility with existing component descriptors.
- README updated: input table re-sorted alphabetically (picks up `cache-from`/`cache-to`),
  component field table and examples updated for `build_args`, and a link to the
  `docker/build-push-action` cache docs added.

## Tests / Evidence
- Manual review of `action.yml` shell logic for JSON-object vs. string build-args resolution.
- No automated test suite exists for this composite action (shell-only logic in `action.yml`).

## Additional Notes
None.