### PR TITLE
feat(.github/workflows): add reusable Docker build and Helm release

### DIFF
--- a/.github/workflows/re-infra-docker-build.yaml
+++ b/.github/workflows/re-infra-docker-build.yaml
@@ -1,0 +1,156 @@
+name: "[REUSABLE] [INFRA] Docker Build"
+
+on:
+  workflow_call:
+    inputs:
+      tags:
+        required: false
+        type: string
+        default: ""
+        description: "Tags"
+      dry-run:
+        required: true
+        type: string
+        default: "false"
+        description: "Dry run mode"
+      replace-symbol:
+        required: false
+        type: string
+        default: "_"
+        description: "Symbol to replace in tags"
+      config-file:
+        required: true
+        type: string
+        description: "Path to config file"
+      diff-build:
+        required: false
+        type: string
+        default: "true"
+        description: "Diff build mode"
+      max-parallel:
+        required: false
+        type: number
+        default: 4
+        description: "Maximum number of parallel jobs"
+
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    name: "Prepare Images and Metadata"
+    runs-on: ubuntu-latest
+    outputs:
+      components: "${{ steps.load-config.outputs.config }}"
+      tags: "${{ steps.meta.outputs.result }}"
+    env:
+      CONFIG_FILE: ${{ inputs.config-file }}
+      DRY_RUN: ${{ inputs.dry-run }}
+      DIFF_BUILD: ${{ inputs.diff-build }}
+      TAGS: ${{ inputs.tags }}
+      REPLACE_SYMBOL: ${{ inputs.replace-symbol }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: true
+          fetch-depth: 0
+
+      - name: Changed Files
+        if: env.DIFF_BUILD == 'true'
+        id: changed-files
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
+        with:
+          json: true
+          write_output_files: true # .github/outputs/all_changed_files.json
+
+      - name: Filter config for changed components
+        id: filter-config
+        if: env.DIFF_BUILD == 'true' && steps.changed-files.outputs.all_modified_files_count != '0'
+        run: |
+          set -euo pipefail
+
+          config_file="${{ env.CONFIG_FILE }}"
+          files_file=".github/outputs/all_changed_files.json"
+          out_file="${{ env.CONFIG_FILE }}"
+
+          if [ ! -f "$config_file" ]; then
+            echo "Config file not found: $config_file" >&2
+            exit 1
+          fi
+
+          if [ ! -f "$files_file" ]; then
+            echo "Changed files json not found: $files_file" >&2
+            exit 1
+          fi
+
+          # Compute filtered components (array)
+          filtered=$(jq -c --argjson files "$(cat "$files_file")" '
+          .components |
+          [ .[] | select(
+              . as $component |
+              any($files[];
+                  [ $component.changeset[] as $ch | startswith($ch) ] | any
+              )
+              )
+          ]
+          ' "$config_file")
+
+          # If nothing matched, return empty array and exit
+          if [ "$filtered" = "[]" ] || [ -z "$filtered" ]; then
+            # output original config with empty components array
+            jq '.components = []' "$config_file" > "$out_file"
+            echo "No matching components found for changed files. Output config with empty components array."
+            echo "⚠️ No matching components found for changed files." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # Inject filtered components into the original config and write output
+          jq --argjson comps "$filtered" '.components = $comps' "$config_file" > "$out_file"
+
+      - name: Load Config
+        id: load-config
+        uses: netcracker/qubership-workflow-hub/actions/docker-config-resolver@27fd7674286e5f561a6fd8277f2f389ff96ddb9e #v2.6.0
+        with:
+          file-path: ${{ env.CONFIG_FILE }}
+
+      - name: Create tags for images
+        uses: netcracker/qubership-workflow-hub/actions/metadata-action@27fd7674286e5f561a6fd8277f2f389ff96ddb9e #v2.6.0
+        id: meta
+        with:
+          default-template: "{{ref-name}}"
+          extra-tags: ${{ env.TAGS || '' }}
+          replace-symbol: ${{ env.REPLACE_SYMBOL || '_'}}
+
+  build:
+    name: ${{ matrix.component.name }} Image Build
+    needs: [prepare]
+    runs-on: ubuntu-latest
+    if: needs.prepare.outputs.components != '[]' && needs.prepare.outputs.components != ''
+    permissions:
+      contents: read
+      packages: write
+    env:
+      CONFIG_FILE: ${{ inputs.config-file }}
+      DRY_RUN: ${{ inputs.dry-run }}
+      DIFF_BUILD: ${{ inputs.diff-build }}
+      TAGS: ${{ inputs.tags }}
+      REPLACE_SYMBOL: ${{ inputs.replace-symbol }}
+    strategy:
+      max-parallel: ${{ inputs.max-parallel }}
+      fail-fast: false
+      matrix:
+        component: ${{ fromJson(needs.prepare.outputs.components) }}
+    steps:
+      - name: Docker
+        uses: netcracker/qubership-workflow-hub/actions/docker-action@27fd7674286e5f561a6fd8277f2f389ff96ddb9e #v2.6.0
+        with:
+          ref: ${{ github.ref }}
+          dry-run: ${{ env.DRY_RUN == 'true' }}
+          download-artifact: false
+          component: ${{ toJson(matrix.component) }}
+          platforms: ${{ matrix.component.platforms }}
+          tags: ${{ needs.prepare.outputs.tags }}
+          cache-from: type=gha,scope=${{ matrix.component.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.component.name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/re-infra-docker-build.yaml
+++ b/.github/workflows/re-infra-docker-build.yaml
@@ -9,7 +9,7 @@ on:
         default: ""
         description: "Tags"
       dry-run:
-        required: true
+        required: false
         type: string
         default: "false"
         description: "Dry run mode"

--- a/.github/workflows/re-infra-docker-build.yaml
+++ b/.github/workflows/re-infra-docker-build.yaml
@@ -52,7 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          persist-credentials: true
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Changed Files

--- a/.github/workflows/re-infra-docker-build.yaml
+++ b/.github/workflows/re-infra-docker-build.yaml
@@ -71,7 +71,7 @@ jobs:
 
           config_file="${{ env.CONFIG_FILE }}"
           files_file=".github/outputs/all_changed_files.json"
-          out_file="${{ env.CONFIG_FILE }}"
+          out_file="${{ env.CONFIG_FILE }}-filtered"
 
           if [ ! -f "$config_file" ]; then
             echo "Config file not found: $config_file" >&2
@@ -106,6 +106,7 @@ jobs:
 
           # Inject filtered components into the original config and write output
           jq --argjson comps "$filtered" '.components = $comps' "$config_file" > "$out_file"
+          cp -f $out_file ${{ env.CONFIG_FILE }}
 
       - name: Load Config
         id: load-config

--- a/.github/workflows/re-infra-helm-release.yaml
+++ b/.github/workflows/re-infra-helm-release.yaml
@@ -1,0 +1,213 @@
+---
+
+name: "[REUSABLE] [INFRA] Helm Charts Release"
+
+on:
+  workflow_call:
+    inputs:
+      release:
+        description: 'Release version'
+        required: true
+        type: string
+      docker-config-file:
+        description: 'Path to docker config file'
+        required: false
+        type: string
+        default: ".qubership/dev-build-config.cfg"
+      helm-charts-config-file:
+        description: 'Path to helm charts config file'
+        required: false
+        type: string
+        default: ".qubership/helm-charts-release-config.yaml"
+      max-parallel:
+        description: 'Maximum number of parallel jobs'
+        required: false
+        type: number
+        default: 4
+
+permissions:
+  contents: read
+
+jobs:
+  check-tag:
+    env:
+      RELEASE_VERSION: ${{ inputs.release }}
+      DOCKER_CONFIG_FILE: ${{ inputs.docker-config-file }}
+      HELM_CHARTS_CONFIG_FILE: ${{ inputs.helm-charts-config-file }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if tag exists
+        id: check_tag
+        uses: netcracker/qubership-workflow-hub/actions/tag-action@27fd7674286e5f561a6fd8277f2f389ff96ddb9e #v2.6.0
+        with:
+          tag-name: '${{ env.RELEASE_VERSION }}'
+          ref: ${{ github.ref }}
+          create-tag: false
+          check-tag: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  load-docker-build-components:
+    env:
+      RELEASE_VERSION: ${{ inputs.release }}
+      DOCKER_CONFIG_FILE: ${{ inputs.docker-config-file }}
+      HELM_CHARTS_CONFIG_FILE: ${{ inputs.helm-charts-config-file }}
+    runs-on: ubuntu-latest
+    outputs:
+      components: ${{ steps.load-config.outputs.config }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        with:
+          persist-credentials: false
+
+      - name: Load Docker Configuration
+        id: load-config
+        uses: netcracker/qubership-workflow-hub/actions/docker-config-resolver@27fd7674286e5f561a6fd8277f2f389ff96ddb9e #v2.6.0
+        with:
+          file-path: ${{ env.DOCKER_CONFIG_FILE }}
+
+  docker-check-build:
+    env:
+      RELEASE_VERSION: ${{ inputs.release }}
+      DOCKER_CONFIG_FILE: ${{ inputs.docker-config-file }}
+      HELM_CHARTS_CONFIG_FILE: ${{ inputs.helm-charts-config-file }}
+    needs: [load-docker-build-components, check-tag]
+    name: ${{ matrix.component.name }} dry run
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: ${{ inputs.max-parallel }}
+      fail-fast: true
+      matrix:
+        component: ${{ fromJson(needs.load-docker-build-components.outputs.components) }}
+    steps:
+      - name: Docker build
+        uses: netcracker/qubership-workflow-hub/actions/docker-action@27fd7674286e5f561a6fd8277f2f389ff96ddb9e #v2.6.0
+        with:
+          ref: ${{ github.ref }}
+          download-artifact: false
+          dry-run: true
+          component: ${{ toJson(matrix.component) }}
+          platforms: ${{ matrix.component.platforms }}
+          tags: "${{ env.RELEASE_VERSION }}_dry_run"
+          cache-from: type=gha,scope=${{ matrix.component.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.component.name }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+  chart-release:
+    permissions:
+      contents: write
+      packages: write
+    env:
+      RELEASE_VERSION: ${{ inputs.release }}
+      DOCKER_CONFIG_FILE: ${{ inputs.docker-config-file }}
+      HELM_CHARTS_CONFIG_FILE: ${{ inputs.helm-charts-config-file }}
+    needs: [check-tag, load-docker-build-components, docker-check-build]
+    runs-on: ubuntu-latest
+    outputs:
+      images-versions: ${{ steps.update-versions.outputs.images-versions }}
+      charts-artifact: ${{ steps.update-versions.outputs.released-chart-atrifact }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: "Add github.vars into github.env"
+        env:
+          VARS_JSON: '${{ toJson(vars) }}'
+        run: |
+          echo "${VARS_JSON}" | jq -r 'to_entries|map("\(.key)=\(.value)")|.[]' >> $GITHUB_ENV
+
+      - name: "Chart release"
+        id: update-versions
+        uses: netcracker/qubership-workflow-hub/actions/charts-values-update-action@27fd7674286e5f561a6fd8277f2f389ff96ddb9e #v2.6.0
+        with:
+          release-version: ${{ env.RELEASE_VERSION }}
+          config-file: ${{ env.HELM_CHARTS_CONFIG_FILE }}
+          default-tag: ${{ env.RELEASE_VERSION }}
+          package-charts: true
+          publish-charts: true
+
+      - name: "Debug"
+        env:
+          IMAGES_VERSIONS: "${{ steps.update-versions.outputs.images-versions }}"
+        run: |
+          echo "Images versions: ${IMAGES_VERSIONS}"
+
+  docker-build:
+    name: ${{ matrix.component.name }}
+    permissions:
+      contents: write
+      packages: write
+    env:
+      RELEASE_VERSION: ${{ inputs.release }}
+      DOCKER_CONFIG_FILE: ${{ inputs.docker-config-file }}
+      HELM_CHARTS_CONFIG_FILE: ${{ inputs.helm-charts-config-file }}
+    needs: [chart-release, load-docker-build-components]
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: ${{ inputs.max-parallel }}
+      fail-fast: true
+      matrix:
+        component: ${{ fromJson(needs.load-docker-build-components.outputs.components) }}
+    steps:
+      - name: Docker build
+        uses: netcracker/qubership-workflow-hub/actions/docker-action@27fd7674286e5f561a6fd8277f2f389ff96ddb9e #v2.6.0
+        with:
+          ref: release-${{ env.RELEASE_VERSION }}
+          download-artifact: false
+          dry-run: false
+          component: ${{ toJson(matrix.component) }}
+          platforms: ${{ matrix.component.platforms }}
+          tags: "${{ env.IMAGE_VERSION }},latest"
+          cache-from: type=gha,scope=${{ matrix.component.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.component.name }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          IMAGE_VERSION: "${{ fromJson(needs.chart-release.outputs.images-versions)[matrix.component.name] || env.RELEASE_VERSION }}"
+
+  github-release:
+    permissions:
+      contents: write
+      packages: write
+    env:
+      RELEASE_VERSION: ${{ inputs.release }}
+      DOCKER_CONFIG_FILE: ${{ inputs.docker-config-file }}
+      HELM_CHARTS_CONFIG_FILE: ${{ inputs.helm-charts-config-file }}
+    needs: [chart-release, docker-build]
+    continue-on-error: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        with:
+          fetch-depth: 0
+          ref: release-${{ env.RELEASE_VERSION }}
+          persist-credentials: true
+
+      - name: "Release-drafter"
+        uses: netcracker/release-drafter@130c08399304912ffe90e9604e4328f2fdcd7619  # v1.0.1
+        with:
+          config-name: release-drafter-config.yml
+          publish: true
+          name: ${{ env.RELEASE_VERSION }}
+          tag: ${{ env.RELEASE_VERSION }}
+          version: ${{ env.RELEASE_VERSION }}
+          commitish: release-${{ env.RELEASE_VERSION }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Download released charts"
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
+        with:
+          artifact-ids: ${{ needs.chart-release.outputs.charts-artifact }}
+      - name: "Upload Assets"
+        uses: netcracker/qubership-workflow-hub/actions/assets-action@b6bee6f61fdc8b367777c1173fc852a58878a6a7  # v2.5.0
+        with:
+          tag: ${{ env.RELEASE_VERSION }}
+          item-path: "./*.tgz"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Summary
Adds two new reusable workflows: `re-infra-docker-build.yaml`, which resolves a
`docker-config-resolver` component list (optionally filtered to only changed components via
`tj-actions/changed-files`), generates tags with `metadata-action`, and builds each component
with `docker-action` (including GHA cache) in a matrix job; and `re-infra-helm-release.yaml`,
which validates the release tag, dry-run builds each Docker component, packages and publishes
Helm charts via `charts-values-update-action`, builds and pushes the release images, and
publishes a GitHub release with `release-drafter` and uploaded chart artifacts.

## Issue

#910 

## Breaking Change?
- [ ] Yes
- [x] No

Both are new reusable workflows — no existing workflow, action, or input is changed.

## Scope / Project
`.github/workflows`

## Implementation Notes
- `re-infra-docker-build.yaml`: `prepare` job optionally filters the resolved component list
  down to components whose `changeset` paths overlap with `tj-actions/changed-files` output
  (`diff-build: true`, the default), then fans out into a `build` matrix job
  (`max-parallel`-bounded) that calls `docker-action` per component with `cache-from`/`cache-to`
  set to `type=gha,scope=<component-name>`.
- `re-infra-helm-release.yaml` is a 6-job pipeline: `check-tag` (validates the release tag
  doesn't already exist) → `load-docker-build-components` (resolves the Docker config) →
  `docker-check-build` (dry-run build per component, `fail-fast: true`) → `chart-release`
  (packages/publishes Helm charts, resolves per-component image versions) → `docker-build`
  (real build/push per component, tagged with the resolved image version or the release
  version) → `github-release` (drafts and publishes the GitHub release, uploads packaged
  charts as release assets).
- All `uses:` references are pinned to full commit SHAs; SHA-to-tag correspondence was
  verified against the GitHub API for every pin in both files.
- Job-level `permissions` are scoped per job (e.g. `contents: read` for read-only jobs,
  `contents: write, packages: write` only for `chart-release`, `docker-build`, and
  `github-release`, which publish charts, images, and releases respectively).

## Tests / Evidence
- Lint audit run: EditorConfig clean (final newline present, no trailing whitespace, CRLF
  line endings consistent with the rest of the repo); no `.md` files in this diff so
  markdown lint was not applicable; zizmor security audit run against both files.
- zizmor found one non-blocking item, left as-is per reviewer direction: the `prepare` job's
  checkout step in `re-infra-docker-build.yaml` sets `persist-credentials: true` even though
  that job only reads config and computes tags (no git push). Flagged for awareness — not
  fixed in this PR.
- No workflow-level dry run was executed against a live consuming repository.

## Additional Notes
None.